### PR TITLE
prepare for signaturehelp implementation using next roslyn release

### DIFF
--- a/src/CSharpLanguageServer/CSharpLanguageServer.fsproj
+++ b/src/CSharpLanguageServer/CSharpLanguageServer.fsproj
@@ -35,18 +35,18 @@
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.1.0.6543" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1">
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final">
       <NoWarn>NU1604</NoWarn>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final">
       <NoWarn>NU1604</NoWarn>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="4.1.0-1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0-1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="4.1.0-1.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.1.0-1.final" />
     <PackageReference Include="Microsoft.Build" Version="17.0.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="17.0.0" ExcludeAssets="runtime" />
   </ItemGroup>

--- a/src/CSharpLanguageServer/RoslynHelpers.fs
+++ b/src/CSharpLanguageServer/RoslynHelpers.fs
@@ -18,6 +18,7 @@ open Ionide.LanguageServerProtocol
 open Microsoft.CodeAnalysis.MSBuild
 open Microsoft.CodeAnalysis.CodeFixes
 open Microsoft.CodeAnalysis.CSharp.Syntax
+open Microsoft.CodeAnalysis.SignatureHelp
 open System.Collections.Immutable
 
 let roslynTagToLspCompletion tag =
@@ -458,6 +459,9 @@ let refactoringProviderInstances =
 let codeFixProviderInstances =
     instantiateRoslynProviders<CodeFixProvider>
         (fun _ -> true)
+
+let signatureHelpProviderInstances =
+    instantiateRoslynProviders<ISignatureHelpProvider> (fun _ -> true)
 
 let tryLoadSolutionOnPath logMessage solutionPath = async {
     try

--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -439,7 +439,10 @@ let setupServerHandlers options lspClient =
                                Some
                                     { FirstTriggerCharacter = ';'
                                       MoreTriggerCharacter = Some([| '}'; ')' |]) }
-                        SignatureHelpProvider = None
+                        SignatureHelpProvider =
+                            Some { TriggerCharacters = Some [| '('; ',' |]
+                                   RetriggerCharacters = Some [| ','; ')' |]
+                                 }
                         CompletionProvider =
                             Some { ResolveProvider = None
                                    TriggerCharacters = Some ([| '.'; '''; |])
@@ -963,6 +966,12 @@ let setupServerHandlers options lspClient =
         return WorkspaceEdit.Create (docChanges |> Array.ofList, scope.ClientCapabilities.Value) |> Some |> success
     }
 
+    let handleTextDocumentSignatureHelp (scope: ServerRequestScope) (helpParams: Types.SignatureHelpParams): AsyncLspResult<Types.SignatureHelp option> = async {
+        //let! maybeSymbol = scope.GetSymbolAtPositionOnUserDocument helpParams.TextDocument.Uri helpParams.Position
+
+        return None |> success
+    }
+
     let handleWorkspaceSymbol (scope: ServerRequestScope) (symbolParams: Types.WorkspaceSymbolParams): AsyncLspResult<Types.SymbolInformation [] option> = async {
         let! symbols = findSymbolsInSolution scope.Solution symbolParams.Query (Some 20)
         return symbols |> Array.ofSeq |> Some |> success
@@ -1060,6 +1069,7 @@ let setupServerHandlers options lspClient =
         "textDocument/rangeFormatting"   , handleTextDocumentRangeFormatting   |> withReadOnlyScope |> requestHandling
         "textDocument/references"        , handleTextDocumentReferences        |> withReadOnlyScope |> requestHandling
         "textDocument/rename"            , handleTextDocumentRename            |> withReadOnlyScope |> requestHandling
+        "textDocument/signatureHelp"     , handleTextDocumentSignatureHelp     |> withReadOnlyScope |> requestHandling
         "workspace/symbol"               , handleWorkspaceSymbol               |> withReadOnlyScope |> requestHandling
         "csharp/metadata"                , handleCSharpMetadata                |> withReadOnlyScope |> requestHandling
     ]


### PR DESCRIPTION
it seems like there is bits already just not released:
- https://github.com/dotnet/roslyn/blob/main/src/Features/Core/Portable/SignatureHelp/ISignatureHelpProvider.cs

otherwise we'd have to look at what omnisharp-roslyn does, but this would be much easier..