### PR TITLE
change CodeAnalysis.AddImport kind to quickfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [Unreleased]
+- change `CodeAnalysis.AddImport` kind to `quickfix`
+  - this will show add missing imports in vscode's quick fix panel
+
 # 0.4.2-Randamonys
 - Don't register capabilities when initialized, but after "initialized" has been received from the client;
   - this makes us more LSP-spec compatible;

--- a/src/CSharpLanguageServer/RoslynHelpers.fs
+++ b/src/CSharpLanguageServer/RoslynHelpers.fs
@@ -164,7 +164,7 @@ let asyncMaybeOnException op = async {
 let lspCodeActionDetailsFromRoslynCA ca =
     let typeName = ca.GetType() |> string
     if typeName.Contains("CodeAnalysis.AddImport") then
-        Some Types.CodeActionKind.SourceOrganizeImports, Some true
+        Some Types.CodeActionKind.QuickFix, Some true
     else
         None, None
 


### PR DESCRIPTION
this shows add imports under vscode's quickfix menu.

Not sure though if it doesn't break other clients