### PR TITLE
Fix URI parse error

### DIFF
--- a/src/CSharpLanguageServer/State.fs
+++ b/src/CSharpLanguageServer/State.fs
@@ -110,14 +110,14 @@ type ServerStateEvent =
     | PeriodicTimerTick
 
 let getDocumentForUriOfType state docType (u: string) =
-    let uri = Uri u
+    let uri = Uri(u.Replace("%3A", ":", true, null))
 
     match state.Solution with
     | Some solution ->
         let matchingUserDocuments =
             solution.Projects
             |> Seq.collect (fun p -> p.Documents)
-            |> Seq.filter (fun d -> Uri("file://" + d.FilePath) = uri) |> List.ofSeq
+            |> Seq.filter (fun d -> Uri(d.FilePath, UriKind.Absolute) = uri) |> List.ofSeq
 
         let matchingUserDocumentMaybe =
             match matchingUserDocuments with


### PR DESCRIPTION
1. Replace "%3A" with ":": Some lsp client will escape ":" with "%3A", while the constructor of System.Uri will not unescape "%3A". So unescaping "%3A" manually before passing it to the constructor.
2. Don't concat "file://" manually: Uri("file://" + path) is not equal to Uri(path) because path might contain chars that are interpreted (# and ?). For example, if path is "/mnt/code/c#/project", then the former will treat "/mnt/code/c" as LocalPath and "/project" asFragment.