### PR TITLE
Inlay hint support

### DIFF
--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -279,6 +279,7 @@ let setupServerHandlers options (lspClient: LspClient) =
                                    Range = Some true
                                    Full = true |> First |> Some
                                  }
+                        InlayHintProvider = Some { ResolveProvider = Some false }
                     }
               }
 


### PR DESCRIPTION
This PR is trying to add support for inlay hint. In fact, Roslyn has
already implemented the feature via language service in
https://github.com/dotnet/roslyn/blob/main/src/Features/CSharp/Portable/InlineHints/CSharpInlineTypeHintsService.cs &
https://github.com/dotnet/roslyn/blob/main/src/Features/CSharp/Portable/InlineHints/CSharpInlineParameterNameHintsService.cs.
However, the implementation and the interface, `IInlineHintsService`,
are `internal`, so we can't call the implementation directly (we can't
even get the implementation via
`doc.Project.LanguageServices.GetRequiredService<IInlineHintsService>`).

Hence, this PR rewrites the implementation using F#. Unlike the
implementation in Roslyn, however, this PR always puts type inlay hints
after the identifier and parameter inlay hints before the argument, just
like what clangd does, because not only will it keep the implementation
simple, but also it's the position I like.