### PR TITLE
fix: Fix crash if there is no newline at the end of the last line

### DIFF
--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -476,7 +476,7 @@ let setupServerHandlers settings (lspClient: LspClient) =
 
             let textSpan =
                 actionParams.Range
-                |> roslynLinePositionSpanForLspRange
+                |> roslynLinePositionSpanForLspRange docText.Lines
                 |> docText.Lines.GetTextSpan
 
             let! roslynCodeActions =
@@ -548,7 +548,7 @@ let setupServerHandlers settings (lspClient: LspClient) =
 
             let textSpan =
                        resolutionData.Value.Range
-                       |> roslynLinePositionSpanForLspRange
+                       |> roslynLinePositionSpanForLspRange docText.Lines
                        |> docText.Lines.GetTextSpan
 
             let! roslynCodeActions =
@@ -871,8 +871,8 @@ let setupServerHandlers settings (lspClient: LspClient) =
                         |> Option.defaultValue false
 
                     let linePositionSpan = LinePositionSpan(
-                        roslynLinePositionForLspPosition prepareRename.Position,
-                        roslynLinePositionForLspPosition prepareRename.Position)
+                        roslynLinePositionForLspPosition docText.Lines prepareRename.Position,
+                        roslynLinePositionForLspPosition docText.Lines prepareRename.Position)
 
                     let textSpan = docText.Lines.GetTextSpan(linePositionSpan)
 
@@ -1120,7 +1120,7 @@ let setupServerHandlers settings (lspClient: LspClient) =
                 match range with
                 | Some r ->
                     r
-                    |> roslynLinePositionSpanForLspRange
+                    |> roslynLinePositionSpanForLspRange sourceText.Lines
                     |> sourceText.Lines.GetTextSpan
                 | None ->
                     TextSpan(0, sourceText.Length)
@@ -1269,7 +1269,7 @@ let setupServerHandlers settings (lspClient: LspClient) =
             let! sourceText = doc.GetTextAsync() |> Async.AwaitTask
             let textSpan =
                 inlayHintParams.Range
-                |> roslynLinePositionSpanForLspRange
+                |> roslynLinePositionSpanForLspRange sourceText.Lines
                 |> sourceText.Lines.GetTextSpan
 
             let inlayHints =


### PR DESCRIPTION
The `Range` may extend the actual range of the text according to the doc of LSP:
> ... the end position is exclusive. If you want to specify a range
> that contains a line including the line ending character(s) then use
> an end position denoting the start of the next line.

If there is no newline at the end of the last line (which is common for files created by Vistual Studio) and client set the end of Range to the start of the next line of the last line, then csharp-ls will crash because argument is out of the range. On the other hand, we SHOULDN'T trust the value client sent to us.