### PR TITLE
fix: Semantic token types

### DIFF
--- a/src/CSharpLanguageServer/Util.fs
+++ b/src/CSharpLanguageServer/Util.fs
@@ -42,33 +42,35 @@ let rec unpackException (exn : Exception) =
     | _ -> exn
 
 let ClassificationTypeMap = Map [
-    (ClassificationTypeNames.ClassName,           "class");
-    (ClassificationTypeNames.Comment,             "comment");
-    (ClassificationTypeNames.ConstantName,        "property");
-    (ClassificationTypeNames.ControlKeyword,      "keyword");
-    (ClassificationTypeNames.DelegateName,        "class");
-    (ClassificationTypeNames.EnumMemberName,      "enumMember");
-    (ClassificationTypeNames.EnumName,            "enum");
-    (ClassificationTypeNames.EventName,           "event");
-    (ClassificationTypeNames.ExtensionMethodName, "method");
-    (ClassificationTypeNames.FieldName,           "property");
-    (ClassificationTypeNames.InterfaceName,       "interface");
-    (ClassificationTypeNames.LabelName,           "label");
-    (ClassificationTypeNames.LocalName,           "variable");
-    (ClassificationTypeNames.Keyword,             "keyword");
-    (ClassificationTypeNames.MethodName,          "method");
-    (ClassificationTypeNames.NamespaceName,       "namespace");
-    (ClassificationTypeNames.NumericLiteral,      "number");
-    (ClassificationTypeNames.Operator,            "operator");
-    (ClassificationTypeNames.OperatorOverloaded,  "operator");
-    (ClassificationTypeNames.ParameterName,       "parameter");
-    (ClassificationTypeNames.PropertyName,        "property");
-    (ClassificationTypeNames.RecordClassName,     "class");
-    (ClassificationTypeNames.RecordStructName,    "struct");
-    (ClassificationTypeNames.RegexText,           "regex");
-    (ClassificationTypeNames.StringLiteral,       "string");
-    (ClassificationTypeNames.StructName,          "struct");
-    (ClassificationTypeNames.TypeParameterName,   "typeParameter")
+    (ClassificationTypeNames.ClassName,             "class");
+    (ClassificationTypeNames.Comment,               "comment");
+    (ClassificationTypeNames.ConstantName,          "property");
+    (ClassificationTypeNames.ControlKeyword,        "keyword");
+    (ClassificationTypeNames.DelegateName,          "class");
+    (ClassificationTypeNames.EnumMemberName,        "enumMember");
+    (ClassificationTypeNames.EnumName,              "enum");
+    (ClassificationTypeNames.EventName,             "event");
+    (ClassificationTypeNames.ExtensionMethodName,   "method");
+    (ClassificationTypeNames.FieldName,             "property");
+    (ClassificationTypeNames.Identifier,            "variable");
+    (ClassificationTypeNames.InterfaceName,         "interface");
+    (ClassificationTypeNames.LabelName,             "variable");
+    (ClassificationTypeNames.LocalName,             "variable");
+    (ClassificationTypeNames.Keyword,               "keyword");
+    (ClassificationTypeNames.MethodName,            "method");
+    (ClassificationTypeNames.NamespaceName,         "namespace");
+    (ClassificationTypeNames.NumericLiteral,        "number");
+    (ClassificationTypeNames.Operator,              "operator");
+    (ClassificationTypeNames.OperatorOverloaded,    "operator");
+    (ClassificationTypeNames.ParameterName,         "parameter");
+    (ClassificationTypeNames.PropertyName,          "property");
+    (ClassificationTypeNames.RecordClassName,       "class");
+    (ClassificationTypeNames.RecordStructName,      "struct");
+    (ClassificationTypeNames.RegexText,             "regex");
+    (ClassificationTypeNames.StringLiteral,         "string");
+    (ClassificationTypeNames.StructName,            "struct");
+    (ClassificationTypeNames.TypeParameterName,     "typeParameter");
+    (ClassificationTypeNames.VerbatimStringLiteral, "string")
 ]
 
 let ClassificationModifierMap = Map [


### PR DESCRIPTION
1. Add the following missing ClassificationTypeNames -> semantic token maps:
   1. Identifier: variable
   2. VerbatimStringLiteral: string
2. Fix the following ClassificationTypeNames -> semantic token map since there is no related semantic token:
   1. LabelName: label -> variable

Now `ClassificationTypeMap` should cover all possible return values of [Microsoft.CodeAnalysis.CSharp.Classification.ClassificationHelpers.GetClassification](https://github.com/dotnet/roslyn/blob/main/src/Workspaces/CSharp/Portable/Classification/ClassificationHelpers.cs).