### PR TITLE
Omit solution path from 'csharp' settings when not set

### DIFF
--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -330,7 +330,11 @@ let setupServerHandlers settings (lspClient: LspClient) =
 
                       match csharpSettingsMaybe with
                       | Some csharpSettings ->
-                          Some { scope.State.Settings with SolutionPath = csharpSettings.solution }
+
+                          match csharpSettings.solution with
+                          | Some solutionPath-> Some { scope.State.Settings with SolutionPath = Some solutionPath }
+                          | _ -> None
+
                       | _ -> None
                   | _ -> None
 


### PR DESCRIPTION
Fixes when solution path retrieval from settings when it's not set.

From vscode I do launch server with `dotnet /.../CSharpLanguageServer.dll --solution my-solution.sln`. And if in vscode settings (it merges global user settings and workspace settings) I have at least one setting that starts with `csharp.` (for example `"csharp.debug.console": "internalConsole"`) then csharp language server ignores solution path from command line and tries to search all projects in cwd. This happens due to when parsing settings from client it sets solution path to `None`.
And looks like official C# vscode extension has lot's of settings that starts with `csharp.`:  https://github.com/dotnet/vscode-csharp/blob/7dc5cbd809aa2d3b304e32c55271a78b021ec29e/package.json#L902 and all of them will be retrieved with https://github.com/razzmatazz/csharp-language-server/blob/80687719e19aafb33fc48a045c3df7df334aadec/src/CSharpLanguageServer/Server.fs#L318-L319