### PR TITLE
wrapping error check for invocation

### DIFF
--- a/src/CSharpLanguageServer/RoslynHelpers.fs
+++ b/src/CSharpLanguageServer/RoslynHelpers.fs
@@ -892,22 +892,23 @@ type MoveStaticMembersOptionsServiceInterceptor (_logMessage) =
             | _ ->
                 NotImplementedException(string invocation.Method) |> raise
 
-let invocationCheck (invocation: IInvocation) (name: String) =
-    try
-        if invocation.Method.Name = name && invocation.ReturnValue = null then
-            null
-        else
-            invocation.ReturnValue
-    with
-    | _ ->
-        null
 
 type WorkspaceServicesInterceptor (logMessage) =
     interface IInterceptor with
         member __.Intercept(invocation: IInvocation) =
             invocation.Proceed()
 
-            if invocationCheck invocation "GetService" = null then
+            let check (invocation: IInvocation) =
+                try
+                    if invocation.Method.Name = "GetService" && invocation.ReturnValue = null then
+                        null
+                    else
+                        invocation.ReturnValue
+                    with
+                        | _ ->
+                            null
+
+            if check invocation = null then
                 let updatedReturnValue =
                     let serviceType = invocation.GenericArguments[0]
                     let generator = ProxyGenerator()

--- a/src/CSharpLanguageServer/RoslynHelpers.fs
+++ b/src/CSharpLanguageServer/RoslynHelpers.fs
@@ -892,12 +892,22 @@ type MoveStaticMembersOptionsServiceInterceptor (_logMessage) =
             | _ ->
                 NotImplementedException(string invocation.Method) |> raise
 
+let invocationCheck (invocation: IInvocation) (name: String) =
+    try
+        if invocation.Method.Name = name && invocation.ReturnValue = null then
+            null
+        else
+            invocation.ReturnValue
+    with
+    | _ ->
+        null
+
 type WorkspaceServicesInterceptor (logMessage) =
     interface IInterceptor with
         member __.Intercept(invocation: IInvocation) =
             invocation.Proceed()
 
-            if invocation.Method.Name = "GetService" && invocation.ReturnValue = null then
+            if invocationCheck invocation "GetService" = null then
                 let updatedReturnValue =
                     let serviceType = invocation.GenericArguments[0]
                     let generator = ProxyGenerator()


### PR DESCRIPTION
So if this dependency isnt loaded roslyn throws an exception instead of just returning null (no idea if this is new behavior from them. Their PR process is more involved than I care to do while on a cruise ship. This should allow us to register the right dependency on failure or null.

this should close https://github.com/razzmatazz/csharp-language-server/issues/103 this issue