### PR TITLE
Add support for textDocument/typeDefinition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 .ionide/
 .idea/
 .config/
+nupkg/

--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -703,9 +703,9 @@ let setupServerHandlers settings (lspClient: LspClient) =
                     | None -> []
 
                 let typeSymbols = 
-                    if symbols.IsEmpty then
-                        []
-                    else
+                    match symbols with 
+                    | [] -> []
+                    | _  ->
                         match symbols.Head with
                         | :? ILocalSymbol as loc -> [loc.Type]
                         | :? IFieldSymbol as field -> [field.Type]
@@ -713,7 +713,6 @@ let setupServerHandlers settings (lspClient: LspClient) =
                         | :? IParameterSymbol as param -> [param.Type]
                         | _ -> []
 
-                let! compilation = doc.Project.GetCompilationAsync(ct) |> Async.AwaitTask
                 let! locations =
                      scope.ResolveTypeSymbolLocations doc.Project typeSymbols 
 

--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -696,14 +696,24 @@ let setupServerHandlers settings (lspClient: LspClient) =
                 let! sourceText = doc.GetTextAsync(ct) |> Async.AwaitTask
                 let position = sourceText.Lines.GetPosition(LinePosition(def.Position.Line, def.Position.Character))
                 let! symbolMaybe = SymbolFinder.FindSymbolAtPositionAsync(doc, position, ct) |> Async.AwaitTask
+                let! semanticModel = doc.GetSemanticModelAsync() |> Async.AwaitTask;
 
                 let symbols =
                     match Option.ofObj symbolMaybe with
-                    | Some sym -> [sym.ContainingType]
+                    | Some sym -> [sym]
                     | None -> []
 
+                let typeSymbols = 
+                    match symbols.Head with
+                    | :? ILocalSymbol as loc -> [loc.Type]
+                    | :? IFieldSymbol as field -> [field.Type]
+                    | :? IPropertySymbol as prop -> [prop.Type]
+                    | :? IParameterSymbol as param -> [param.Type]
+                    | _ -> []
+
+                let! compilation = doc.Project.GetCompilationAsync(ct) |> Async.AwaitTask
                 let! locations =
-                     scope.GetSymbolAtPositionOfType doc.Project symbols
+                     scope.ResolveTypeSymbolLocations doc.Project typeSymbols 
 
                 return locations |> Array.ofSeq |> GotoResult.Multiple |> Some |> success
               }

--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -696,7 +696,6 @@ let setupServerHandlers settings (lspClient: LspClient) =
                 let! sourceText = doc.GetTextAsync(ct) |> Async.AwaitTask
                 let position = sourceText.Lines.GetPosition(LinePosition(def.Position.Line, def.Position.Character))
                 let! symbolMaybe = SymbolFinder.FindSymbolAtPositionAsync(doc, position, ct) |> Async.AwaitTask
-                let! semanticModel = doc.GetSemanticModelAsync() |> Async.AwaitTask;
 
                 let symbols =
                     match Option.ofObj symbolMaybe with
@@ -704,12 +703,15 @@ let setupServerHandlers settings (lspClient: LspClient) =
                     | None -> []
 
                 let typeSymbols = 
-                    match symbols.Head with
-                    | :? ILocalSymbol as loc -> [loc.Type]
-                    | :? IFieldSymbol as field -> [field.Type]
-                    | :? IPropertySymbol as prop -> [prop.Type]
-                    | :? IParameterSymbol as param -> [param.Type]
-                    | _ -> []
+                    if symbols.IsEmpty then
+                        []
+                    else
+                        match symbols.Head with
+                        | :? ILocalSymbol as loc -> [loc.Type]
+                        | :? IFieldSymbol as field -> [field.Type]
+                        | :? IPropertySymbol as prop -> [prop.Type]
+                        | :? IParameterSymbol as param -> [param.Type]
+                        | _ -> []
 
                 let! compilation = doc.Project.GetCompilationAsync(ct) |> Async.AwaitTask
                 let! locations =

--- a/src/CSharpLanguageServer/Server.fs
+++ b/src/CSharpLanguageServer/Server.fs
@@ -227,7 +227,7 @@ let setupServerHandlers settings (lspClient: LspClient) =
                                else
                                    true |> First |> Some
                         DefinitionProvider = Some true
-                        TypeDefinitionProvider = None
+                        TypeDefinitionProvider = Some true
                         ImplementationProvider = Some true
                         ReferencesProvider = Some true
                         DocumentHighlightProvider = Some true

--- a/src/CSharpLanguageServer/State.fs
+++ b/src/CSharpLanguageServer/State.fs
@@ -396,6 +396,24 @@ type ServerRequestScope (requestId: int, state: ServerState, emitServerEvent, lo
         return aggregatedLspLocations
     }
 
+
+    member scope.ResolveTypeSymbolLocations
+            (project: Microsoft.CodeAnalysis.Project)
+            (symbols: Microsoft.CodeAnalysis.ITypeSymbol list) = async {
+        let! ct = Async.CancellationToken
+        let! compilation = project.GetCompilationAsync(ct) |> Async.AwaitTask
+
+        let mutable aggregatedLspLocations = []
+
+        for sym in symbols do
+            for l in sym.Locations do
+                let! symLspLocations = scope.ResolveSymbolLocation compilation project sym l
+
+                aggregatedLspLocations <- aggregatedLspLocations @ symLspLocations
+
+        return aggregatedLspLocations
+    }
+
 type DiagnosticsEvent =
     | DocumentOpenOrChange of string * DateTime
     | DocumentClose of string


### PR DESCRIPTION
Resolves #120.

Tested locally using neovim and this seems to work. For decompiled types using , this will require making [csharpls-extended-lsp.nvim](https://github.com/Decodetalkers/csharpls-extended-lsp.nvim) the handler for `textDocument/typeDefinition` e.g.

```lua
require('lspconfig').csharp_ls.setup({
   ...
     handlers = {
         ["textDocument/definition"] = require('csharpls_extended').handler,
         ["textDocument/typeDefinition"] = require('csharpls_extended').handler
     }
   ...
 })

```