### PR TITLE
Update Roslyn 4.7.0->4.9.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RoslynPackageVersion>4.7.0</RoslynPackageVersion>
+    <RoslynPackageVersion>4.9.2</RoslynPackageVersion>
     <MSBuildPackageVersion>17.7.2</MSBuildPackageVersion>
   </PropertyGroup>
 
@@ -34,7 +34,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NUnit" Version="3.13.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="Serilog" Version="3.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="1.5.0" />


### PR DESCRIPTION
This PR fixes https://github.com/razzmatazz/csharp-language-server/issues/140

Before any code changes:
```csharp
#error version    Compiler version: '4.7.0-3.23416.9 (43b0b05c)'. Language version: default (11.0).
```

I updated the packages, built locally, and set my path to use the new executable:
```
$ dotnet build --configuration Release
$ mv csharp-language-server/src/CSharpLanguageServer/bin/Release/net8.0/CSharpLanguageServer csharp-language-server/src/CSharpLanguageServer/bin/Release/net8.0/csharp-ls
$ export PATH="/path/to/csharp-language-server/src/CSharpLanguageServer/bin/Release/net8.0:$PATH"
```

Now my editor reports C# 12 and the errors from preview features are gone:
```csharp
#error version    Compiler version: '4.9.2-3.24129.6 (9934fb9e)'. Language version: 12.0.
```
