### PR TITLE
Add UriKind.RelativeOrAbsolute

### DIFF
--- a/src/CSharpLanguageServer/Conversions.fs
+++ b/src/CSharpLanguageServer/Conversions.fs
@@ -22,7 +22,7 @@ module Uri =
         if path.StartsWith(metadataPrefix) then
             "csharp:/metadata/" + path.Substring(metadataPrefix.Length)
         else
-            Uri(path).ToString()
+            Uri(path, UriKind.RelativeOrAbsolute).ToString()
 
     let toWorkspaceFolder(uri: string): WorkspaceFolder =
         { Uri = uri


### PR DESCRIPTION
I was running into an issue with `UriFormat` errors. Reading the dotnet docs, if a relative path is passed into the `Uri` constructor, it throws this error. By adding `UriKind.RelativeOrAbsolute` to the constructor, the errors go away and everything works as expected:

https://learn.microsoft.com/en-us/dotnet/api/system.uri.-ctor?view=net-8.0#system-uri-ctor(system-string-system-urikind)



```
lsp-request: System.UriFormatException: Invalid URI: The format of the URI could not be determined.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at CSharpLanguageServer.Conversions.Uri.fromPath(String path) in /home/jonny/programming/csharp-language-server/src/CSharpLanguageServer/Conversions.fs:line 25
   at CSharpLanguageServer.Conversions.Path.toUri@33.Invoke(String path)
   at CSharpLanguageServer.Conversions.Location.fromRoslynLocation(Location loc) in /home/jonny/programming/csharp-language-server/src/CSharpLanguageServer/Conversions.fs:line 71
   at CSharpLanguageServer.Handlers.References.Pipe #1 stage #2 at line 49@49-1.Invoke(ReferenceLocation rl) in /home/jonny/programming/csharp-language-server/src/CSharpLanguageServer/Handlers/References.fs:line 49
   at Microsoft.FSharp.Collections.Internal.IEnumerator.map@99.DoMoveNext(b& curr) in D:\a\_work\1\s\src\FSharp.Core\seq.fs:line 102
   at Microsoft.FSharp.Collections.Internal.IEnumerator.MapEnumerator‘1.System.Collections.IEnumerator.MoveNext() in D:\a\_work\1\s\src\FSharp.Core\seq.fs:line 84
   at Microsoft.FSharp.Collections.SeqModule.Distinct@1316.GenerateNext(IEnumerable‘1& next) in D:\a\_work\1\s\src\FSharp.Core\seq.fs:line 1318
   at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase‘1.MoveNextImpl() in D:\a\_work\1\s\src\FSharp.Core\seqcore.fs:line 427
   at Microsoft.FSharp.Core.CompilerServices.GeneratedSequenceBase‘1.System.Collections.IEnumerator.MoveNext() in D:\a\_work\1\s\src\FSharp.Core\seqcore.fs:line 469
   at System.Collections.Generic.List‘1..ctor(IEnumerable‘1 collection)
   at Microsoft.FSharp.Collections.SeqModule.ToArray[T](IEnumerable‘1 source) in D:\a\_work\1\s\src\FSharp.Core\seq.fs:line 989
   at CSharpLanguageServer.Handlers.References.handle@46-163.Invoke(IEnumerable‘1 _arg2) in /home/jonny/programming/csharp-language-server/src/CSharpLanguageServer/Handlers/References.fs:line 51
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck[a,b](AsyncActivation‘1 ctxt, b result1, FSharpFunc‘2 userCode) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 525
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc‘2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112

```