### PR TITLE
Add automatic .editorconfig support

### DIFF
--- a/src/CSharpLanguageServer/Handlers/DocumentFormatting.fs
+++ b/src/CSharpLanguageServer/Handlers/DocumentFormatting.fs
@@ -41,7 +41,7 @@ module DocumentFormatting =
         | None -> return None |> success
         | Some doc ->
             let! ct = Async.CancellationToken
-            let options = FormatUtil.getFormattingOptions doc p.Options
+            let! options = doc.GetOptionsAsync() |> Async.AwaitTask
             let! newDoc = Formatter.FormatAsync(doc, options, cancellationToken=ct) |> Async.AwaitTask
             let! textEdits = FormatUtil.getChanges newDoc doc
             return textEdits |> Some |> success

--- a/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/.editorconfig
+++ b/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*.cs]
+csharp_space_after_keywords_in_control_flow_statements = false
+csharp_space_before_open_square_brackets = true
+csharp_space_after_cast = true
+csharp_new_line_before_open_brace = none
+csharp_indent_switch_labels = false

--- a/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/Class.cs
+++ b/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/Class.cs
@@ -1,0 +1,29 @@
+// csharp_space_after_keywords_in_control_flow_statements = false
+if (true) ;
+
+// csharp_space_before_open_square_brackets = true
+var array = new int[10];
+
+// csharp_space_after_cast = true
+var num = (int)15.0;
+
+// csharp_new_line_before_open_brace = none
+void foo()
+{
+
+}
+
+// csharp_indent_switch_labels = true
+switch (Random.Shared.Next(3))
+{
+    case 1:
+        Console.WriteLine("Case 1");
+        break;
+    case 2:
+        Console.WriteLine("Case 2");
+        break;
+    default:
+        Console.WriteLine("Default case");
+        break;
+}
+

--- a/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/ExpectedFormatting.cs.txt
+++ b/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/ExpectedFormatting.cs.txt
@@ -1,0 +1,27 @@
+// csharp_space_after_keywords_in_control_flow_statements = false
+if(true) ;
+
+// csharp_space_before_open_square_brackets = true
+var array = new int [10];
+
+// csharp_space_after_cast = true
+var num = (int) 15.0;
+
+// csharp_new_line_before_open_brace = none
+void foo() {
+
+}
+
+// csharp_indent_switch_labels = true
+switch(Random.Shared.Next(3)) {
+case 1:
+    Console.WriteLine("Case 1");
+    break;
+case 2:
+    Console.WriteLine("Case 2");
+    break;
+default:
+    Console.WriteLine("Default case");
+    break;
+}
+

--- a/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/Project.csproj
+++ b/tests/CSharpLanguageServer.Tests/TestData/testEditorConfigFormatting/Project/Project.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+</Project>


### PR DESCRIPTION
#49 
Now the document is formatted according to the rules of the .editorconfig file, if such a file is present in the solution.