### PR TITLE
fix(logging): Reduce startup notifications by using "window/logMessage"

### DIFF
--- a/src/CSharpLanguageServer/Handlers/Initialization.fs
+++ b/src/CSharpLanguageServer/Handlers/Initialization.fs
@@ -26,7 +26,7 @@ module Initialization =
                          (p: InitializeParams)
             : Async<LspResult<InitializeResult>> = async {
         // context.State.LspClient has not been initialized yet thus context.WindowShowMessage will not work
-        let windowShowMessage m = lspClient.WindowShowMessage({ Type = MessageType.Info; Message = m })
+        let windowShowMessage m = lspClient.WindowLogMessage({ Type = MessageType.Info; Message = m })
 
         context.Emit(ClientChange (Some lspClient))
 


### PR DESCRIPTION
Problem: The server pushes a lot of notifications to the client using "window/showMessage".  All messages are pure informational.

Fix: use "window/logMessage" for all messages that are not errors, Still use "window/showMessage" for errors and exceptions