### PR TITLE
Get diagnostic url from Roslyn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+* Use diagnostic url from Roslyn
+
 ## [0.17.0] - 2025-04-30 / Krokšlys
 * Upgrade Roslyn to 4.13.0
   - https://github.com/razzmatazz/csharp-language-server/pull/220

--- a/src/CSharpLanguageServer/Conversions.fs
+++ b/src/CSharpLanguageServer/Conversions.fs
@@ -233,13 +233,11 @@ module DiagnosticSeverity =
 
 module Diagnostic =
     let fromRoslynDiagnostic (diagnostic: Microsoft.CodeAnalysis.Diagnostic): Diagnostic =
-        let diagnosticCodeUrl =
-            diagnostic.Id.ToLowerInvariant()
-            |> sprintf "https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/%s"
+        let diagnosticCodeUrl = diagnostic.Descriptor.HelpLinkUri |> Option.ofObj
         { Range = diagnostic.Location.GetLineSpan().Span |> Range.fromLinePositionSpan
           Severity = Some (diagnostic.Severity |> DiagnosticSeverity.fromRoslynDiagnosticSeverity)
           Code = Some (U2.C2 diagnostic.Id)
-          CodeDescription = Some { Href = diagnosticCodeUrl |> URI }
+          CodeDescription = diagnosticCodeUrl |> Option.map (fun x -> { Href = x |> URI })
           Source = Some "lsp"
           Message = diagnostic.GetMessage()
           RelatedInformation = None

--- a/tests/CSharpLanguageServer.Tests/DiagnosticTests.fs
+++ b/tests/CSharpLanguageServer.Tests/DiagnosticTests.fs
@@ -90,7 +90,7 @@ let testPullDiagnosticsWork () =
         Assert.AreEqual(Some DiagnosticSeverity.Error, diagnostic0.Severity)
         Assert.AreEqual("Identifier expected", diagnostic0.Message)
         Assert.AreEqual(
-            "https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1001",
+            "https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS1001)",
             diagnostic0.CodeDescription.Value.Href)
 
         let diagnostic1 = report.Items.[1]


### PR DESCRIPTION
Not all diagnostics will necessarily follow that format so we can just get them from Roslyn.
This also enables things like custom URLS for obsolete warnings.

I'm not sure about how to use the CHANGELOG.md so any guidance there would be appreciated.