### PR TITLE
Fix logging context for exception when projects cannot be opened

### DIFF
--- a/src/CSharpLanguageServer/RoslynHelpers.fs
+++ b/src/CSharpLanguageServer/RoslynHelpers.fs
@@ -615,7 +615,7 @@ let tryLoadSolutionFromProjectFiles
                 logger.error (
                     Log.setMessage "could not OpenProjectAsync('{file}'): {exception}"
                     >> Log.addContext "file" file
-                    >> Log.addContext "ex" (string ex)
+                    >> Log.addContext "exception" (string ex)
                 )
             let projectFile = new FileInfo(file)
             let projName = projectFile.Name


### PR DESCRIPTION
The context variable is incorrect and the exception message is not getting printed to the logs. When the log got printed it use the `{exception}` place holder for example:

```log
could not OpenProjectAsync('/path/to/file.csproj'): {exception}
```