### PR TITLE
Attempt to load a solution file even if multiple found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Apply simple heuristics to select a .sln/.slnx file when multiple are found.
+  - https://github.com/razzmatazz/csharp-language-server/pull/250
 * Print error mesage to stderr in case of invalid args or a server crash.
   - Fixed by @zachristmas in https://github.com/zachristmas/csharp-language-server
 * Fix completion item kind for an extension method


### PR DESCRIPTION
This applies somewhat naive heuristics on the sln files discovered to select the one that has the most projects specified.

Loading projects one-by-one otherwise (when no .sln file is selected) is very slow and this should help it in some cases where the user has not provided a path to .sln file.