### PR TITLE
Use a common target framework from all of your projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Select common target framework when multiple projects are found
+  - By @AdeAttwood in https://github.com/razzmatazz/csharp-language-server/pull/253
 * Fix how completion item details are resolved
   - https://github.com/razzmatazz/csharp-language-server/pull/251
 * Apply simple heuristics to select a .sln/.slnx file when multiple are found.

--- a/tests/CSharpLanguageServer.Tests/InternalTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InternalTests.fs
@@ -5,15 +5,16 @@ open NUnit.Framework
 
 open CSharpLanguageServer.RoslynHelpers
 
-[<TestCase("1.csproj:net8.0", null)>]
+[<TestCase("1.csproj:net8.0", "net8.0")>]
 [<TestCase("1.csproj:net8.0,net10.0", "net10.0")>]
 [<TestCase("1.csproj:net8.0,netstandard2.0", "net8.0")>]
 [<TestCase("1.csproj:netstandard1.0,netstandard2.0", "netstandard2.0")>]
 [<TestCase("1.csproj:net40,net462,net6.0,net8.0,netcoreapp3.1,netstandard2.0", "net8.0")>]
 [<TestCase("1.csproj:net40,net462", "net462")>]
-[<TestCase("1.csproj:net8.0 2.csproj:net8.0", null)>]
+[<TestCase("1.csproj:net8.0 2.csproj:net8.0", "net8.0")>]
 [<TestCase("1.csproj:net8.0,net10.0 2.csproj:netstandard2.0,net462", null)>]
 [<TestCase("1.csproj:net8.0,net10.0 2.csproj:net8.0,net10.0", "net10.0")>]
+[<TestCase("1.csproj:net8.0 2.csproj:net8.0,net10.0", "net8.0")>]
 let testApplyWorkspaceTargetFrameworkProp(tfmList: string, expectedTfm: string | null) =
 
     let parseTfmList (projectEntry: string) : string * list<string> =
@@ -33,3 +34,9 @@ let testApplyWorkspaceTargetFrameworkProp(tfmList: string, expectedTfm: string |
     let props = Map.empty |> applyWorkspaceTargetFrameworkProp tfmsPerProject
 
     Assert.AreEqual(expectedTfm |> Option.ofObj, props |> Map.tryFind "TargetFramework")
+
+[<TestCase>]
+let testApplyWorkspaceTargetFrameworkPropWithEmptyMap() =
+    let props = Map.empty |> applyWorkspaceTargetFrameworkProp Map.empty
+
+    Assert.AreEqual(None, props |> Map.tryFind "TargetFramework")

--- a/tests/CSharpLanguageServer.Tests/InternalTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InternalTests.fs
@@ -1,15 +1,35 @@
 module CSharpLanguageServer.Tests.InternalTests
 
+open System
 open NUnit.Framework
 
 open CSharpLanguageServer.RoslynHelpers
 
-[<TestCase("net8.0", "net8.0")>]
-[<TestCase("net8.0;net10.0", "net10.0")>]
-[<TestCase("net8.0;netstandard2.0", "net8.0")>]
-[<TestCase("netstandard1.0;netstandard2.0", "netstandard2.0")>]
-[<TestCase("net40;net462;net6.0;net8.0;netcoreapp3.1;netstandard2.0", "net8.0")>]
-[<TestCase("net40;net462", "net462")>]
-let testTheLatestTfmIsSelected(tfmList: string, expectedTfm: string) =
-    let selectedTfm = tfmList.Split(";") |> selectLatestTfm
-    Assert.AreEqual(expectedTfm |> Option.ofObj, selectedTfm)
+[<TestCase("1.csproj:net8.0", null)>]
+[<TestCase("1.csproj:net8.0,net10.0", "net10.0")>]
+[<TestCase("1.csproj:net8.0,netstandard2.0", "net8.0")>]
+[<TestCase("1.csproj:netstandard1.0,netstandard2.0", "netstandard2.0")>]
+[<TestCase("1.csproj:net40,net462,net6.0,net8.0,netcoreapp3.1,netstandard2.0", "net8.0")>]
+[<TestCase("1.csproj:net40,net462", "net462")>]
+[<TestCase("1.csproj:net8.0 2.csproj:net8.0", null)>]
+[<TestCase("1.csproj:net8.0,net10.0 2.csproj:netstandard2.0,net462", null)>]
+[<TestCase("1.csproj:net8.0,net10.0 2.csproj:net8.0,net10.0", "net10.0")>]
+let testApplyWorkspaceTargetFrameworkProp(tfmList: string, expectedTfm: string | null) =
+
+    let parseTfmList (projectEntry: string) : string * list<string> =
+        let parts = projectEntry.Split(':')
+        if parts.Length <> 2 then
+            failwithf "Invalid project entry format: '%s'. Expected 'ProjectName:tfm1,tfm2,...'" projectEntry
+        let projectName = parts.[0]
+        let tfmStrings = parts.[1].Split(',') |> List.ofSeq
+        (projectName, tfmStrings)
+
+    let tfmsPerProject: Map<string, list<string>> =
+        tfmList
+        |> _.Split([|' '|], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.map parseTfmList
+        |> Map.ofArray
+
+    let props = Map.empty |> applyWorkspaceTargetFrameworkProp tfmsPerProject
+
+    Assert.AreEqual(expectedTfm |> Option.ofObj, props |> Map.tryFind "TargetFramework")

--- a/tests/CSharpLanguageServer.Tests/InternalTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InternalTests.fs
@@ -10,6 +10,6 @@ open CSharpLanguageServer.RoslynHelpers
 [<TestCase("netstandard1.0;netstandard2.0", "netstandard2.0")>]
 [<TestCase("net40;net462;net6.0;net8.0;netcoreapp3.1;netstandard2.0", "net8.0")>]
 [<TestCase("net40;net462", "net462")>]
-let testTheMostCapableTfmIsSelected(tfmList: string, expectedTfm: string) =
-    let selectedTfm = tfmList.Split(";") |> selectMostCapableCompatibleTfm
+let testTheLatestTfmIsSelected(tfmList: string, expectedTfm: string) =
+    let selectedTfm = tfmList.Split(";") |> selectLatestTfm
     Assert.AreEqual(expectedTfm |> Option.ofObj, selectedTfm)


### PR DESCRIPTION
Summary:

When using multiple target frameworks in multiple projects. We are currently resolving the latest target framework that exists over all of your projects. The issue with this is the selected target framework may not work with some of the projects.

This resolves the latest target framework that exists in all of your projects. This will give the best framework compatibility.

Test Plan:

Unit test for the existing select latest framework is still there. I have also tested this locally over a project that uses `net8.0` and `net10.0` in some projects.

<img width="911" height="122" alt="Screenshot 2025-08-13 095612" src="https://github.com/user-attachments/assets/1004a3ef-7756-4b85-9d59-d015016755de" />


Ref: #75