### PR TITLE
add suggestion to install dotnet sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/281
 * Fix how title is formatted for nested code actions
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/295
+* Add suggestion to install specific dotnet sdk version
+  - By @jhamm in https://github.com/razzmatazz/csharp-language-server/pull/299
+  - Reported by @pandasoli in https://github.com/razzmatazz/csharp-language-server/issues/215
 
 **Full Changelog**: https://github.com/razzmatazz/csharp-language-server/compare/0.20.0...0.21.0
 

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -32,6 +32,9 @@ let initializeMSBuild () : unit =
                 "No instances of MSBuild could be detected."
                 + Environment.NewLine
                 + "Try calling RegisterInstance or RegisterMSBuildPath to manually register one."
+                + Environment.NewLine
+                + "Or try installing the dotnet sdk version: "
+                + sprintf "%i.%i." Environment.Version.Major Environment.Version.Minor
             )
         )
 


### PR DESCRIPTION
- #215 No instances of MSBuild could be detected.
- In the MsBuildLocator DotNetSdkLocationHelper.GetInstance, it compares the SDK version to the Environment.Version
- This could help new user setup.