### PR TITLE
Implementation: also enumerate derived classes for class symbols

### DIFF
--- a/src/CSharpLanguageServer/Handlers/Implementation.fs
+++ b/src/CSharpLanguageServer/Handlers/Implementation.fs
@@ -46,9 +46,22 @@ module Implementation =
 
         match wf.Solution with
         | Ready(_, solution) ->
-            let! impls =
+            let! baseImpls =
                 SymbolFinder.FindImplementationsAsync(sym, solution, cancellationToken = ct)
                 |> Async.AwaitTask
+
+            // FindImplementationsAsync on a class symbol returns only interface
+            // implementations, not derived classes. For class symbols also enumerate
+            // transitively-derived classes via FindDerivedClassesAsync so
+            // textDocument/implementation behaves correctly on class declarations.
+            let! derivedClasses =
+                match sym with
+                | :? INamedTypeSymbol as nts when nts.TypeKind = TypeKind.Class ->
+                    SymbolFinder.FindDerivedClassesAsync(nts, solution, true, cancellationToken = ct)
+                    |> Async.AwaitTask
+                | _ -> async { return Seq.empty }
+
+            let impls = Seq.append baseImpls (derivedClasses |> Seq.cast<ISymbol>)
 
             let mutable aggregatedWf = wf
             let mutable aggregatedWfUpdates = []


### PR DESCRIPTION
## Problem

`textDocument/implementation` currently returns an empty result for any class symbol — both abstract and concrete. The handler in `Handlers/Implementation.fs` calls only `SymbolFinder.FindImplementationsAsync`, which Roslyn limits to interface implementors and interface-member implementors. For class symbols, the right Roslyn API is `SymbolFinder.FindDerivedClassesAsync`, which the handler never invokes.

This makes \"go to implementations\" effectively unusable for codebases organised primarily around class hierarchies — Unity projects are a common case but it affects any C# codebase that uses base classes more than interfaces.

## Reproduction

On a Unity project (~2,150 .cs files, ~50 csproj loaded by one .sln):

| Symbol | Expected | csharp-ls 0.24 (stock) | Microsoft Roslyn LSP |
|---|---|---|---|
| Concrete class with 82 transitive derived types | 82 | **0** | 82 |
| Abstract class with 17 direct derived types | 17 | **0** | 17 |
| Interface with one implementor | 1 | 1 ✓ | 1 ✓ |

Independently verified against `AppDomain.GetAssemblies()` + `IsAssignableFrom` reflection — the 82-result count is the source of truth.

## Fix

In `findImplLocationsOfSymbol`, after the existing `FindImplementationsAsync` call, also call `FindDerivedClassesAsync` when the symbol is an `INamedTypeSymbol` of `TypeKind.Class`, then merge the two result sets. Pattern is copied verbatim from `Handlers/TypeHierarchy.fs:153`, which already uses `FindDerivedClassesAsync` correctly elsewhere in the codebase.

\`\`\`fsharp
let! derivedClasses =
    match sym with
    | :? INamedTypeSymbol as nts when nts.TypeKind = TypeKind.Class ->
        SymbolFinder.FindDerivedClassesAsync(nts, solution, true, cancellationToken = ct)
        |> Async.AwaitTask
    | _ -> async { return Seq.empty }

let impls = Seq.append baseImpls (derivedClasses |> Seq.cast<ISymbol>)
\`\`\`

\`transitive: true\` matches the LSP-spec semantics for `textDocument/implementation` (\"all symbols that implement\"), and matches what Microsoft's official Roslyn LSP returns for the same query.

## After patch (same project)

| Symbol | After patch |
|---|---|
| Concrete class with 82 transitive derived types | **82** ✓ in 6 ms warm |
| Abstract class with 17 direct derived types | **17** ✓ in 6 ms warm |
| Interface (regression check) | 1 ✓ |
| `findReferences` (regression check) | 13 ms warm — unchanged |

Net cost for symbols that aren't classes is one allocation of `Seq.empty`.

## Notes

- Doesn't touch struct/record/enum/delegate symbols — `FindDerivedClassesAsync` only accepts `INamedTypeSymbol` of `TypeKind.Class`. Records-as-classes are covered (records have `TypeKind.Class` in Roslyn).
- Doesn't address the related case of `goToImplementation` on a virtual/abstract method on a class — that would need `FindOverridesAsync`. Happy to add it in a follow-up if the maintainers want this PR to stay focused on class derivation.