### PR TITLE
Implementation: also enumerate derived classes for class symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+* Fix `textDocument/implementation` returning no results for class symbols; derived classes are now returned via `FindDerivedClassesAsync` in addition to interface implementors
+  - By @dee-rv in https://github.com/razzmatazz/csharp-language-server/pull/360
 
 ## [0.24.0] - 2026-04-16 / Ignalina
 * Fix pull diagnostics with VS Code: stop `workspace/diagnostic` busy loop, clear stale diagnostics after `analyzersEnabled` toggle, re-fetch config on `workspace/didChangeConfiguration`

--- a/src/CSharpLanguageServer/Handlers/Implementation.fs
+++ b/src/CSharpLanguageServer/Handlers/Implementation.fs
@@ -46,9 +46,22 @@ module Implementation =
 
         match wf.Solution with
         | Ready(_, solution) ->
-            let! impls =
+            let! baseImpls =
                 SymbolFinder.FindImplementationsAsync(sym, solution, cancellationToken = ct)
                 |> Async.AwaitTask
+
+            // FindImplementationsAsync on a class symbol returns only interface
+            // implementations, not derived classes. For class symbols also enumerate
+            // transitively-derived classes via FindDerivedClassesAsync so
+            // textDocument/implementation behaves correctly on class declarations.
+            let! derivedClasses =
+                match sym with
+                | :? INamedTypeSymbol as nts when nts.TypeKind = TypeKind.Class ->
+                    SymbolFinder.FindDerivedClassesAsync(nts, solution, true, cancellationToken = ct)
+                    |> Async.AwaitTask
+                | _ -> async { return Seq.empty }
+
+            let impls = Seq.append baseImpls (derivedClasses |> Seq.cast<ISymbol>)
 
             let mutable aggregatedWf = wf
             let mutable aggregatedWfUpdates = []

--- a/src/CSharpLanguageServer/Handlers/Implementation.fs
+++ b/src/CSharpLanguageServer/Handlers/Implementation.fs
@@ -54,12 +54,16 @@ module Implementation =
             // implementations, not derived classes. For class symbols also enumerate
             // transitively-derived classes via FindDerivedClassesAsync so
             // textDocument/implementation behaves correctly on class declarations.
-            let! derivedClasses =
+            let! derivedClasses = async {
                 match sym with
                 | :? INamedTypeSymbol as nts when nts.TypeKind = TypeKind.Class ->
-                    SymbolFinder.FindDerivedClassesAsync(nts, solution, true, cancellationToken = ct)
-                    |> Async.AwaitTask
-                | _ -> async { return Seq.empty }
+                    let! derivedClasses =
+                        SymbolFinder.FindDerivedClassesAsync(nts, solution, true, cancellationToken = ct)
+                        |> Async.AwaitTask
+
+                    return derivedClasses |> List.ofSeq
+                | _ -> return []
+            }
 
             let impls = Seq.append baseImpls (derivedClasses |> Seq.cast<ISymbol>)
 

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/ClassAndInterfaceHierarchy.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/ClassAndInterfaceHierarchy.cs
@@ -36,3 +36,13 @@ class Student : Person
         return $"Hi, I'm {Name} and I'm in grade {Grade}.";
     }
 }
+
+abstract class Animal
+{
+    public abstract string Sound();
+}
+
+class Dog : Animal
+{
+    public override string Sound() => "Woof";
+}

--- a/tests/CSharpLanguageServer.Tests/ImplementationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/ImplementationTests.fs
@@ -30,3 +30,83 @@ let testTextDocumentImplementationWorks () =
         Assert.AreEqual(18u, locations[0].Range.Start.Line)
 
     | _ -> failwithf "Some Location[] was expected but %s received" (string implementation0)
+
+[<Test>]
+let testImplementationOnConcreteClassWorks () =
+    // PR #360: FindDerivedClassesAsync is now called for class symbols.
+    // Cursor on `Person` (concrete class) should return Student as a derived class.
+    use client = activateFixture "genericProject"
+    use hierarchyFile = client.Open "Project/ClassAndInterfaceHierarchy.cs"
+
+    // Line 9 (0-indexed), Character 6 is on "Person" in "class Person : IGreetable"
+    let implParams: ImplementationParams =
+        { TextDocument = { Uri = hierarchyFile.Uri }
+          Position = { Line = 9u; Character = 6u }
+          WorkDoneToken = None
+          PartialResultToken = None }
+
+    let result: U2<Definition, DefinitionLink array> option =
+        client.Request("textDocument/implementation", implParams)
+
+    // Should find Student (line 24) as the class derived from Person
+    match result with
+    | Some(U2.C1(U2.C2 locations)) ->
+        Assert.AreEqual(1, locations.Length)
+        Assert.AreEqual(hierarchyFile.Uri, locations[0].Uri)
+        Assert.AreEqual(24u, locations[0].Range.Start.Line)
+
+    | _ -> failwithf "Some Location[] was expected but %s received" (string result)
+
+[<Test>]
+let testImplementationOnAbstractClassWorks () =
+    // PR #360: Cursor on an abstract class symbol should return all derived classes.
+    // `Animal` (abstract, line 39) has one direct subclass: Dog (line 44).
+    use client = activateFixture "genericProject"
+    use hierarchyFile = client.Open "Project/ClassAndInterfaceHierarchy.cs"
+
+    // Line 39 (0-indexed), Character 15 is on "Animal" in "abstract class Animal"
+    let implParams: ImplementationParams =
+        { TextDocument = { Uri = hierarchyFile.Uri }
+          Position = { Line = 39u; Character = 15u }
+          WorkDoneToken = None
+          PartialResultToken = None }
+
+    let result: U2<Definition, DefinitionLink array> option =
+        client.Request("textDocument/implementation", implParams)
+
+    // Should find Dog (line 44) as the class derived from Animal
+    match result with
+    | Some(U2.C1(U2.C2 locations)) ->
+        Assert.AreEqual(1, locations.Length)
+        Assert.AreEqual(hierarchyFile.Uri, locations[0].Uri)
+        Assert.AreEqual(44u, locations[0].Range.Start.Line)
+
+    | _ -> failwithf "Some Location[] was expected but %s received" (string result)
+
+[<Test>]
+let testImplementationOnInterfaceTypeWorks () =
+    // Regression check for PR #360: cursor on an interface type (not a method) should
+    // still return the implementing class (Person), not break due to the new class-path.
+    use client = activateFixture "genericProject"
+    use hierarchyFile = client.Open "Project/ClassAndInterfaceHierarchy.cs"
+
+    // Line 4 (0-indexed), Character 10 is on "IGreetable" in "interface IGreetable"
+    let implParams: ImplementationParams =
+        { TextDocument = { Uri = hierarchyFile.Uri }
+          Position = { Line = 4u; Character = 10u }
+          WorkDoneToken = None
+          PartialResultToken = None }
+
+    let result: U2<Definition, DefinitionLink array> option =
+        client.Request("textDocument/implementation", implParams)
+
+    // FindImplementationsAsync on an interface type returns all classes in the
+    // hierarchy that carry the implementation: Person (direct implementor, line 9)
+    // and Student (inherits the implementation transitively, line 24).
+    match result with
+    | Some(U2.C1(U2.C2 locations)) ->
+        let lines = locations |> Array.map (fun l -> l.Range.Start.Line) |> Array.sort
+        Assert.AreEqual(2, locations.Length)
+        Assert.AreEqual([| 9u; 24u |], lines)
+
+    | _ -> failwithf "Some Location[] was expected but %s received" (string result)


### PR DESCRIPTION
## Problem

`textDocument/implementation` currently returns an empty result for any class symbol — both abstract and concrete. The handler in `Handlers/Implementation.fs` calls only `SymbolFinder.FindImplementationsAsync`, which Roslyn limits to interface implementors and interface-member implementors. For class symbols, the right Roslyn API is `SymbolFinder.FindDerivedClassesAsync`, which the handler never invokes.

This makes "go to implementations" effectively unusable for codebases organised primarily around class hierarchies — Unity projects are a common case but it affects any C# codebase that uses base classes more than interfaces.

## Reproduction

On a Unity project (~2,150 .cs files, ~50 csproj loaded by one .sln):

| Symbol | Expected | csharp-ls 0.24 (stock) | Microsoft Roslyn LSP |
|---|---|---|---|
| Concrete class with 82 transitive derived types | 82 | **0** | 82 |
| Abstract class with 17 direct derived types | 17 | **0** | 17 |
| Interface with one implementor | 1 | 1 ✓ | 1 ✓ |

Independently verified against `AppDomain.GetAssemblies()` + `IsAssignableFrom` reflection — the 82-result count is the source of truth.

## Fix

In `findImplLocationsOfSymbol`, after the existing `FindImplementationsAsync` call, also call `FindDerivedClassesAsync` when the symbol is an `INamedTypeSymbol` of `TypeKind.Class`, then merge the two result sets. Pattern is copied verbatim from `Handlers/TypeHierarchy.fs:153`, which already uses `FindDerivedClassesAsync` correctly elsewhere in the codebase.

\`\`\`fsharp
let! derivedClasses =
    match sym with
    | :? INamedTypeSymbol as nts when nts.TypeKind = TypeKind.Class ->
        SymbolFinder.FindDerivedClassesAsync(nts, solution, true, cancellationToken = ct)
        |> Async.AwaitTask
    | _ -> async { return Seq.empty }

let impls = Seq.append baseImpls (derivedClasses |> Seq.cast<ISymbol>)
\`\`\`

`transitive: true` matches the LSP-spec semantics for `textDocument/implementation` ("all symbols that implement"), and matches what Microsoft's official Roslyn LSP returns for the same query.

## After patch (same project)

| Symbol | After patch |
|---|---|
| Concrete class with 82 transitive derived types | **82** ✓ in 6 ms warm |
| Abstract class with 17 direct derived types | **17** ✓ in 6 ms warm |
| Interface (regression check) | 1 ✓ |
| `findReferences` (regression check) | 13 ms warm — unchanged |

Net cost for symbols that aren't classes is one allocation of `Seq.empty`.

## Notes

- Doesn't touch struct/record/enum/delegate symbols — `FindDerivedClassesAsync` only accepts `INamedTypeSymbol` of `TypeKind.Class`. Records-as-classes are covered (records have `TypeKind.Class` in Roslyn).
- Doesn't address the related case of `goToImplementation` on a virtual/abstract method on a class — that would need `FindOverridesAsync`. Happy to add it in a follow-up if the maintainers want this PR to stay focused on class derivation.