### PR TITLE
Upgrade Roslyn to 5.6.0 and MSBuild to 18.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 * Upgrade Roslyn (`Microsoft.CodeAnalysis.*`) packages to 5.6.0 and MSBuild (`Microsoft.Build`/`Microsoft.Build.Framework`) packages to 18.7.1
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/374
+* Fix Razor support breaking on .NET SDK 10.0.300+: the Razor source generator's `HintName` format
+  changed to preserve `/` directory separators instead of flattening them to `_`; `solutionGetRazorDocumentForPath`
+  now matches both the old (SDK ≤ 10.0.2xx) and new (SDK ≥ 10.0.300) formats
+  - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/374
 * Fix `textDocument/implementation` and `textDocument/references` (with `includeDeclaration`) returning no locations for BCL/decompiled symbols; definition locations are now resolved via `workspaceFolderSymbolLocations`, triggering decompilation when `useMetadataUris` is enabled, just like `textDocument/definition`
   - Reported by @stigl-cc in https://github.com/razzmatazz/csharp-language-server/issues/319
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Upgrade Roslyn (`Microsoft.CodeAnalysis.*`) packages to 5.6.0
+  - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/374
 * Fix `textDocument/implementation` and `textDocument/references` (with `includeDeclaration`) returning no locations for BCL/decompiled symbols; definition locations are now resolved via `workspaceFolderSymbolLocations`, triggering decompilation when `useMetadataUris` is enabled, just like `textDocument/definition`
   - Reported by @stigl-cc in https://github.com/razzmatazz/csharp-language-server/issues/319
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-* Upgrade Roslyn (`Microsoft.CodeAnalysis.*`) packages to 5.6.0
+* Upgrade Roslyn (`Microsoft.CodeAnalysis.*`) packages to 5.6.0 and MSBuild (`Microsoft.Build`/`Microsoft.Build.Framework`) packages to 18.7.1
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/374
 * Fix `textDocument/implementation` and `textDocument/references` (with `includeDeclaration`) returning no locations for BCL/decompiled symbols; definition locations are now resolved via `workspaceFolderSymbolLocations`, triggering decompilation when `useMetadataUris` is enabled, just like `textDocument/definition`
   - Reported by @stigl-cc in https://github.com/razzmatazz/csharp-language-server/issues/319

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <MSBuildPackageVersion>18.4.0</MSBuildPackageVersion>
-    <RoslynPackageVersion>5.3.0</RoslynPackageVersion>
+    <RoslynPackageVersion>5.6.0</RoslynPackageVersion>
     <MSBuildLocatorPackageVersion>1.10.12</MSBuildLocatorPackageVersion>
     <NoWarn>$(NoWarn);NU1902;NU1903</NoWarn>
   </PropertyGroup>
@@ -31,9 +31,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(RoslynPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynPackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NuGet.Frameworks" Version="6.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <PropertyGroup>
-    <MSBuildPackageVersion>18.4.0</MSBuildPackageVersion>
+    <MSBuildPackageVersion>18.7.1</MSBuildPackageVersion>
     <RoslynPackageVersion>5.6.0</RoslynPackageVersion>
     <MSBuildLocatorPackageVersion>1.10.12</MSBuildLocatorPackageVersion>
     <NoWarn>$(NoWarn);NU1902;NU1903</NoWarn>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ and potentially earlier ones.
 csharp-ls is MIT-licensed (see [LICENSE](LICENSE)) and is provided with no
 warranty of any kind.
 
+# AI Assistance
+
+This project has been developed with substantial help from LLMs, including the following models:
+
+- `anthropic/claude-opus-4-6`
+- `anthropic/claude-sonnet-4-6`
+- `anthropic/claude-sonnet-5`
+
+Source files carry an `Assisted-by:` header line per the
+[Linux kernel coding-assistants convention](https://docs.kernel.org/process/coding-assistants.html#attribution).
+
 # Documentation
 
 See [CHANGELOG.md](CHANGELOG.md) for the list of recent improvements/fixes.

--- a/plans/razor-sdk-300-investigation.md
+++ b/plans/razor-sdk-300-investigation.md
@@ -5,6 +5,40 @@ from 10.0.200 to 10.0.300.
 
 ---
 
+## Update (2026-07): resolved after Roslyn 5.6.0 upgrade
+
+After bumping `RoslynPackageVersion` to `5.6.0` in `Directory.Packages.props`, the version
+mismatch described in "Root Cause — Layer 3" is gone: SDK 10.0.300/10.0.301's
+`Microsoft.CodeAnalysis.Razor.Compiler.dll` requires assembly version `5.5.0.0`, and the
+NuGet-provided `Microsoft.CodeAnalysis.dll` is now `5.6.0.0` — `GetGenerators()` loads
+successfully and `GetSourceGeneratedDocumentsAsync()` returns documents again.
+
+However, a **second, previously-undiscovered breaking change** surfaced once generation
+started working: the Razor generator's `HintName` format changed between the SDK 10.0.1xx
+band and 10.0.300+.
+
+- SDK 10.0.1xx (Roslyn ~5.0–5.3): directory separators **and** the extension dot are both
+  flattened to `_` — `Views/Test/ViewFileWithErrors.cshtml` → `Views_Test_ViewFileWithErrors_cshtml.g.cs`
+- SDK 10.0.300+ (Roslyn ~5.5+): directory separators are preserved as `/` (Roslyn supports
+  hierarchical hint names) and only the extension dot is flattened —
+  `Views/Test/ViewFileWithErrors.cshtml` → `Views/Test/ViewFileWithErrors_cshtml.g.cs`
+
+`solutionGetRazorDocumentForPath` (`src/CSharpLanguageServer/Roslyn/Solution.fs`) now builds
+both candidate suffixes and matches `HintName.EndsWith` against either, so Razor support works
+across both SDK generations without needing to pin a specific band.
+
+As a result, `tests/CSharpLanguageServer.Tests/Fixtures/aspnetProject/global.json` was relaxed
+from pinning the 10.0.1xx feature band (`rollForward: "minor"` on `10.0.100`) to
+`rollForward: "latestMajor"`, so the fixture picks up whatever SDK is newest on the machine —
+confirmed working against SDK 10.0.301 (4/4 Razor tests pass, full suite 212/212).
+
+The root workspace `global.json` (pinning the build/test-runner engine itself) was left
+untouched, since that is orthogonal to which SDK the *project* `Sdk="Microsoft.NET.Sdk.Web"`
+resolves to inside the temp fixture directory (see "The MSBuild engine SDK vs. project SDK"
+section below for why these are independent).
+
+---
+
 ## Symptom
 
 14 integration tests fail with empty/null results. All failures are in tests that exercise

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -472,7 +472,8 @@ let solutionGetRazorDocumentForPath
             let razorGenDoc =
                 generatedDocs
                 |> Seq.tryFind (fun d ->
-                    d.HintName.EndsWith cshtmlHintNameFlat || d.HintName.EndsWith cshtmlHintNameHierarchical)
+                    d.HintName.EndsWith cshtmlHintNameFlat
+                    || d.HintName.EndsWith cshtmlHintNameHierarchical)
 
             match razorGenDoc with
             | None -> return None

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -441,12 +441,28 @@ let solutionGetRazorDocumentForPath
             // build_property.* options it needs — no manual injection required.
             //
             // The Razor generator derives HintNames from the base64-decoded TargetPath in
-            // the editorconfig, replacing BOTH directory separators AND dots with '_', e.g.:
-            //   Views/Test/ViewFileWithErrors.cshtml → Views_Test_ViewFileWithErrors_cshtml.g.cs
-            let cshtmlPathTranslated =
-                Path.GetRelativePath(projectBaseDir, cshtmlPath)
+            // the editorconfig. The exact separator convention has varied across SDK/Roslyn
+            // versions:
+            //   - SDK 10.0.1xx (Roslyn ~5.0-5.3): directory separators AND the extension dot
+            //     are both replaced with '_', e.g.
+            //     Views/Test/ViewFileWithErrors.cshtml → Views_Test_ViewFileWithErrors_cshtml.g.cs
+            //   - SDK 10.0.300+ (Roslyn ~5.5+): directory separators are preserved as '/'
+            //     (Roslyn supports hierarchical hint names) and only the extension dot is
+            //     replaced, e.g.
+            //     Views/Test/ViewFileWithErrors.cshtml → Views/Test/ViewFileWithErrors_cshtml.g.cs
+            // Match against both formats for forward/backward compatibility.
+            let relativeCshtmlPath = Path.GetRelativePath(projectBaseDir, cshtmlPath)
+
+            let cshtmlHintNameFlat =
+                relativeCshtmlPath
                 |> _.Replace(".", "_")
                 |> _.Replace(Path.DirectorySeparatorChar, '_')
+                |> (fun s -> s + ".g.cs")
+
+            let cshtmlHintNameHierarchical =
+                relativeCshtmlPath
+                |> _.Replace(Path.DirectorySeparatorChar, '/')
+                |> _.Replace(".", "_")
                 |> (fun s -> s + ".g.cs")
 
             let! ct = Async.CancellationToken
@@ -454,7 +470,9 @@ let solutionGetRazorDocumentForPath
             let! generatedDocs = project.GetSourceGeneratedDocumentsAsync(ct).AsTask() |> Async.AwaitTask
 
             let razorGenDoc =
-                generatedDocs |> Seq.tryFind (fun d -> d.HintName.EndsWith cshtmlPathTranslated)
+                generatedDocs
+                |> Seq.tryFind (fun d ->
+                    d.HintName.EndsWith cshtmlHintNameFlat || d.HintName.EndsWith cshtmlHintNameHierarchical)
 
             match razorGenDoc with
             | None -> return None

--- a/tests/CSharpLanguageServer.Tests/DiagnoseCommandTests.fs
+++ b/tests/CSharpLanguageServer.Tests/DiagnoseCommandTests.fs
@@ -17,6 +17,7 @@ let testDiagnoseCommandWorks () =
 
     let testAssemblyLocationDir =
         Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+        |> nonNull "Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)"
 
     let actualFixtureDir =
         DirectoryInfo(Path.Combine(testAssemblyLocationDir, "..", "..", "..", "Fixtures", fixtureDir))

--- a/tests/CSharpLanguageServer.Tests/Fixtures/aspnetProject/global.json
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/aspnetProject/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "minor"
+    "rollForward": "latestMajor"
   }
 }

--- a/tests/CSharpLanguageServer.Tests/JsonRpcTests.fs
+++ b/tests/CSharpLanguageServer.Tests/JsonRpcTests.fs
@@ -10,6 +10,16 @@ open NUnit.Framework
 
 open CSharpLanguageServer.Runtime.JsonRpc
 
+/// Local copy of CSharpLanguageServer.Util.nonNull — kept independent of the server's
+/// internals so this test file's null-safety plumbing doesn't depend on production code.
+/// NOTE: uses the `'T | null` union annotation rather than the classic `'T when 'T: null`
+/// constraint, since only the former actually clears the nullability of the return type
+/// under F#'s nullness checker (the constraint form still infers 'T as nullable downstream).
+let private nonNull name (value: 'T | null) : 'T =
+    match value |> Option.ofObj with
+    | Some v -> v
+    | None -> raise (Exception(sprintf "A non-null value was expected: %s" name))
+
 /// Helper: encode a JSON-RPC message with Content-Length framing into bytes.
 let private encodeMessage (json: string) =
     let body = Encoding.UTF8.GetBytes(json)
@@ -194,7 +204,11 @@ let testUnregisteredMethodReturnsMethodNotFoundError () =
     let response = responseOpt.Value
     Assert.AreEqual(3, response.GetProperty("id").GetInt32())
     Assert.AreEqual(-32601, response.GetProperty("error").GetProperty("code").GetInt32())
-    Assert.IsTrue(response.GetProperty("error").GetProperty("message").GetString().Contains("Method not found"))
+    Assert.IsTrue(
+        response.GetProperty("error").GetProperty("message").GetString()
+        |> nonNull "error message"
+        |> _.Contains("Method not found")
+    )
 
 [<Test>]
 let testMultipleRequestsAreHandledSequentially () =
@@ -360,7 +374,9 @@ let testNotificationHandlerReceivesCorrectParams () =
                    message = "hello world" |} |}
         )
 
-    let handler ctx = async { capturedParams.Value <- ctx.Params.Value.GetProperty("message").GetString() }
+    let handler ctx = async {
+        capturedParams.Value <- ctx.Params.Value.GetProperty("message").GetString() |> nonNull "message"
+    }
 
     let notificationHandlings = Map.ofList [ "test/log", handler ]
 
@@ -453,7 +469,7 @@ let testNotificationWithIdIsRoutedAsRequest () =
 
     let requestHandler _ctx = async {
         requestHandlerCalled.Value <- true
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     let notificationHandler _ctx = async { notificationHandlerCalled.Value <- true }
@@ -1097,7 +1113,7 @@ let testShutdownWaitsForRunningHandlerToFinish () =
         handlerStarted.Set()
         handlerMayFinish.Wait() |> ignore
         handlerFinished.Value <- true
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1149,7 +1165,7 @@ let testShutdownCancelsRunningHandlerAndThenReturns () =
     let handler _ctx = async {
         handlerStarted.Set()
         do! Async.Sleep 60_000 // would block forever without cancellation
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1210,7 +1226,7 @@ let testShutdownDrainsAllConcurrentHandlers () =
         allStarted.Signal() |> ignore
         do! mayFinishTcs.Task |> Async.AwaitTask
         System.Threading.Interlocked.Increment(finishedCount) |> ignore
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1320,7 +1336,7 @@ let testSendCallDuringShutdownDrainReturnsError () =
         handlerStarted.Set()
         // Await the TCS — this yields the thread so F# async cancellation can fire.
         do! mayFinishTcs.Task |> Async.AwaitTask
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1492,7 +1508,7 @@ let testEofCancelsRunningHandler () =
     let handler _ctx = async {
         handlerStarted.Set()
         do! Async.Sleep 60_000 // would block forever without cancellation
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1536,7 +1552,7 @@ let testEofLateCallReturnsError () =
     let handler _ctx = async {
         handlerStarted.Set()
         do! mayFinishTcs.Task |> Async.AwaitTask
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1595,7 +1611,7 @@ let testEofDrainsAllConcurrentHandlers () =
         allStarted.Signal() |> ignore
         do! mayFinishTcs.Task |> Async.AwaitTask
         System.Threading.Interlocked.Increment(finishedCount) |> ignore
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =
@@ -1783,7 +1799,11 @@ let testSendCallReturnsErrorOnMethodNotFound () =
     match replyTask.Result with
     | Error err ->
         Assert.AreEqual(-32601, err.GetProperty("code").GetInt32())
-        Assert.IsTrue(err.GetProperty("message").GetString().Contains("Method not found"))
+        Assert.IsTrue(
+            err.GetProperty("message").GetString()
+            |> nonNull "error message"
+            |> _.Contains("Method not found")
+        )
     | Ok _ -> Assert.Fail("Expected Error but got Ok")
 
     shutdownJsonRpcTransport server |> Async.RunSynchronously
@@ -2029,7 +2049,8 @@ let testCancelRequestCancelsRunningHandler () =
             .GetProperty("error")
             .GetProperty("message")
             .GetString()
-            .Contains("cancel", StringComparison.OrdinalIgnoreCase)
+        |> nonNull "error message"
+        |> _.Contains("cancel", StringComparison.OrdinalIgnoreCase)
     )
 
     shutdownJsonRpcTransport server |> Async.RunSynchronously
@@ -2140,7 +2161,7 @@ let testHandlerObservesCancellationToken () =
 
             // Block until cancelled
             do! Async.Sleep 30000
-            return Ok(JsonSerializer.SerializeToElement(null: obj))
+            return Ok(JsonSerializer.SerializeToElement(null: obj | null))
         }
 
     let requestHandlings = Map.ofList [ "test/cancellable", handler ]
@@ -2198,7 +2219,7 @@ let testOtherRequestsStillWorkAfterCancellation () =
     let slowHandler _ctx = async {
         handlerStarted.Set()
         do! Async.Sleep 30000
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     let fastHandler _ctx = async { return Ok(JsonSerializer.SerializeToElement("ok")) }
@@ -2437,7 +2458,7 @@ let testGetRpcStatsRunningHandlerIsVisible () =
         // Use AwaitWaitHandle so the thread-pool thread is released while waiting,
         // leaving the pool free for the actor mailbox and getJsonRpcStats to run.
         do! Async.AwaitWaitHandle(handlerMayFinish.WaitHandle) |> Async.Ignore
-        return Ok(JsonSerializer.SerializeToElement(null: obj))
+        return Ok(JsonSerializer.SerializeToElement(null: obj | null))
     }
 
     use clientToServer =

--- a/tests/CSharpLanguageServer.Tests/JsonRpcTests.fs
+++ b/tests/CSharpLanguageServer.Tests/JsonRpcTests.fs
@@ -204,6 +204,7 @@ let testUnregisteredMethodReturnsMethodNotFoundError () =
     let response = responseOpt.Value
     Assert.AreEqual(3, response.GetProperty("id").GetInt32())
     Assert.AreEqual(-32601, response.GetProperty("error").GetProperty("code").GetInt32())
+
     Assert.IsTrue(
         response.GetProperty("error").GetProperty("message").GetString()
         |> nonNull "error message"
@@ -1799,6 +1800,7 @@ let testSendCallReturnsErrorOnMethodNotFound () =
     match replyTask.Result with
     | Error err ->
         Assert.AreEqual(-32601, err.GetProperty("code").GetInt32())
+
         Assert.IsTrue(
             err.GetProperty("message").GetString()
             |> nonNull "error message"
@@ -2045,10 +2047,7 @@ let testCancelRequestCancelsRunningHandler () =
     )
 
     Assert.IsTrue(
-        response
-            .GetProperty("error")
-            .GetProperty("message")
-            .GetString()
+        response.GetProperty("error").GetProperty("message").GetString()
         |> nonNull "error message"
         |> _.Contains("cancel", StringComparison.OrdinalIgnoreCase)
     )

--- a/tests/CSharpLanguageServer.Tests/Tooling.fs
+++ b/tests/CSharpLanguageServer.Tests/Tooling.fs
@@ -22,6 +22,17 @@ open CSharpLanguageServer.Runtime.DebugInfo
 open CSharpLanguageServer.Types
 open CSharpLanguageServer.Util
 
+/// Local copy of CSharpLanguageServer.Util.nonNull — shadows the one brought in by the
+/// `open` above, kept independent of the server's internals so the test project's
+/// null-safety plumbing doesn't depend on production code.
+/// NOTE: uses the `'T | null` union annotation rather than the classic `'T when 'T: null`
+/// constraint, since only the former actually clears the nullability of the return type
+/// under F#'s nullness checker (the constraint form still infers 'T as nullable downstream).
+let nonNull name (value: 'T | null) : 'T =
+    match value |> Option.ofObj with
+    | Some v -> v
+    | None -> raise (Exception(sprintf "A non-null value was expected: %s" name))
+
 let indexJE (name: string) (je: option<JsonElement>) : option<JsonElement> =
     je
     |> Option.bind (fun p ->
@@ -30,7 +41,7 @@ let indexJE (name: string) (je: option<JsonElement>) : option<JsonElement> =
         | _ -> None)
 
 let jeStringProp (name: string) (je: option<JsonElement>) : option<string> =
-    je |> indexJE name |> Option.map _.GetString()
+    je |> indexJE name |> Option.bind (fun v -> v.GetString() |> Option.ofObj)
 
 let emptyClientCapabilities: ClientCapabilities =
     { Workspace = None
@@ -133,8 +144,11 @@ let defaultClientProfile =
 
 let makeServerProcessInfo projectTempDir =
     let serverExe = Path.Combine(Environment.CurrentDirectory)
-    let tfm = Path.GetFileName(serverExe)
-    let buildMode = Path.GetFileName(Path.GetDirectoryName(serverExe))
+    let tfm = Path.GetFileName(serverExe) |> nonNull "Path.GetFileName(serverExe)"
+
+    let buildMode =
+        Path.GetFileName(Path.GetDirectoryName(serverExe))
+        |> nonNull "Path.GetFileName(Path.GetDirectoryName(serverExe))"
 
     let baseDir =
         serverExe
@@ -143,6 +157,7 @@ let makeServerProcessInfo projectTempDir =
         |> Path.GetDirectoryName
         |> Path.GetDirectoryName
         |> Path.GetDirectoryName
+        |> nonNull "baseDir (walked up 5 directories from serverExe)"
 
     let baseServerFileName =
         Path.Combine(baseDir, "src", "CSharpLanguageServer", "bin", buildMode, tfm, "CSharpLanguageServer")
@@ -480,7 +495,7 @@ let processClientEvent (state: LspClientState) (post: LspClientEvent -> unit) ms
         let readNextStdErrLine () =
             if not state.ServerProcess.Value.HasExited then
                 let line = state.ServerProcess.Value.StandardError.ReadLine()
-                post (ServerStderrLineRead(Some line))
+                post (ServerStderrLineRead(line |> Option.ofObj))
 
         let nextStdErrLineReadTask = Task.Run(readNextStdErrLine)
 
@@ -770,7 +785,9 @@ type LspTestClient(clientProfile: LspClientProfile) =
 
         // prepare temp dir and copy in solution contents
         let testAssemblyLocationDir =
-            Assembly.GetExecutingAssembly().Location |> Path.GetDirectoryName
+            Assembly.GetExecutingAssembly().Location
+            |> Path.GetDirectoryName
+            |> nonNull "Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)"
 
         let sourceTestDataDir =
             Path.Combine(testAssemblyLocationDir, "..", "..", "..", "Fixtures", fixtureName)


### PR DESCRIPTION
## Summary
- Bump `Microsoft.CodeAnalysis.*` to 5.6.0 and `Microsoft.Build*` to 18.7.1 (plus the `Microsoft.Extensions.*` versions Roslyn now requires)
- Fix Razor support breaking on .NET SDK 10.0.300+: the generator's `HintName` format changed to preserve `/` separators; now matches both old and new formats
- Relax the aspnet test fixture's `global.json` to `latestMajor` now that both SDK generations work
- Clean up remaining F# nullness warnings in the test project

🤖 Generated with [ECA](https://eca.dev) (anthropic/claude-sonnet-5)