### PR TITLE
Reduce superfluous inlay hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Reduce superfluous `textDocument/inlayHint` noise: fix the same-name argument suppression gap (multi-line/indented and qualified `this.Foo`-style arguments), suppress uninformative parameter names (short, numbered-suffix, `obj`/sole `value`) and sole-lambda-argument calls, and suppress redundant `var` type hints when the type is already spelled out or echoed by the identifier
+  - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/375
 * Upgrade Roslyn (`Microsoft.CodeAnalysis.*`) packages to 5.6.0 and MSBuild (`Microsoft.Build`/`Microsoft.Build.Framework`) packages to 18.7.1
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/374
 * Fix Razor support breaking on .NET SDK 10.0.300+: the Razor source generator's `HintName` format

--- a/plans/TODO.md
+++ b/plans/TODO.md
@@ -8,43 +8,11 @@ See `plans/test-performance-improvements.md` for the full plan.
 
 ---
 
-## Suppress type inlay hints when type is apparent from the initializer
+## Reduce superfluous inlay hints
 
-**Affects:** `textDocument/inlayHint` — `InlayHint.fs`, `toInlayHint` function.
-
-For `var` declarations where the right-hand side already makes the type obvious to the reader,
-the type inlay hint is redundant noise. Example:
-
-```csharp
-var someValue = getIntAbove10();  // showing `: int` here adds no value
-```
-
-The `VariableDeclarationSyntax` match arm in `toInlayHint` does not currently inspect the
-initializer expression at all — it emits a hint for every `var x = <anything>` as long as the
-type resolves without error.
-
-### Recommended fix
-
-Add an `isTypeApparentFromExpression` helper (mirroring Roslyn's own
-`CSharpInlineTypeHintsService` suppression logic) and call it on the initializer before emitting
-the hint. Suppress when the initializer is one of:
-
-- `InvocationExpressionSyntax` — method/delegate call (`getIntAbove10()`)
-- `ObjectCreationExpressionSyntax` — `new Foo(...)`
-- `CastExpressionSyntax` — `(int)x`
-- `LiteralExpressionSyntax` — `42`, `"hi"`, `true`, `null`
-- `DefaultExpressionSyntax` — `default(T)` / `default`
-- `TypeOfExpressionSyntax` — `typeof(T)`
-- `SizeOfExpressionSyntax` — `sizeof(T)`
-- `BinaryExpressionSyntax` with `AsExpression` kind — `expr as T`
-- `ParenthesizedExpressionSyntax` — recurse into inner expression
-
-The same suppression should be applied to the `DeclarationExpressionSyntax`,
-`SingleVariableDesignationSyntax`, and `ForEachStatementSyntax` arms where an initializer is
-accessible.
-
-The existing TODO comment in the file already notes:
-> `// TODO: Support the configuration whether or not to show some kinds of inlay hints.`
+See `plans/inlay-hint-reduction.md` for the full plan. Exact suppression rules are still to be
+defined during design; the plan file tracks the goal and candidate ideas gathered so far
+(e.g. suppressing `var` type hints when the type is already apparent from the initializer).
 
 ---
 

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -50,7 +50,17 @@ to keep extending for further rules without touching other tests):
   *not* fire when the invocation's return type differs from its type argument (e.g. a hypothetical
   `Describe<Widget>(...)` returning `string` keeps its `: string` hint). Covered by a test using
   the plan's own real BCL example, `Enum.Parse<DayOfWeek>(...)`.
-- Rules #6–#7 below are not yet implemented.
+- ✅ **Rule #6 (identifier-echoes-type-name generalization)** — new `identifierEchoesTypeName`
+  helper (full case-insensitive match, or last-camelCase-word match via `lastWord`) wired into
+  both sides: the `VariableDeclarationSyntax`, `DeclarationExpressionSyntax`,
+  `SingleVariableDesignationSyntax`, and `ForEachStatementSyntax` type-hint match arms (suppress
+  when the declared identifier echoes the inferred type, e.g. `resourceCondition`/
+  `settingChangeCondition` vs. `ResourceCondition`), and a new `validateParameter` match arm (the
+  "narrower, safer sibling" from the evidence: suppress a parameter-name hint when the parameter's
+  own name is a decapitalized echo of its own declared type, e.g. a `MessageDispatcherAsync
+  messageDispatcherAsync` parameter). Both sides covered by matching negative-control tests where
+  the identifier does *not* echo the type.
+- Rule #7 below is not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -676,10 +686,16 @@ first, ranked roughly by combined volume, confidence, and implementation risk:
    both qualified (`Enum.Parse<T>()`) and unqualified (a local generic factory method) call shapes
    without a per-method allow-list, and correctly keeps the hint when the invocation's return type
    differs from its type argument (confirmed via a `Describe<Widget>(...) : string` test).
-6. Generalize the existing same-name suppression (`validateParameter`) to type hints
-   (`validateType`): suppress when the declared variable's identifier is a case-insensitive
+6. **✅ Implemented.** Generalize the existing same-name suppression (`validateParameter`) to type
+   hints (`validateType`): suppress when the declared variable's identifier is a case-insensitive
    match — full or suffix — of the inferred type's name (and, per this sample, consider the same
    for parameter names that are a decapitalized echo of their own type, e.g. `messageDispatcherAsync`).
+   Implemented as `identifierEchoesTypeName` (full case-insensitive match, or last-camelCase-word
+   match, so `settingChangeCondition` vs. `ResourceCondition` — both ending in "Condition" — is
+   caught even though neither is a full match or plain substring of the other), wired into all
+   four identifier-bearing type-hint contexts (`var` declarations, `out var`/deconstruction,
+   pattern-match designations, `foreach` variables) and, for the parameter-name sibling, into
+   `validateParameter`.
 7. Consider suppressing parameter-name hints for arguments to `extern`/P-Invoke-declared methods,
    given their names are typically non-idiomatic, verbatim native-header copies that add little
    without external platform documentation regardless.
@@ -720,16 +736,18 @@ built-in suppression heuristics is also to be decided during design.
    `VariableDeclarationSyntax` match arm, with test coverage for qualified/unqualified matching
    invocations, a non-matching-return-type negative control, and the plan's own
    `Enum.Parse<DayOfWeek>(...)` example.
-6. Design session to enumerate the exact suppression rules for the remaining candidates (rules
-   #6–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
-   Gathered So Far"), informed by the real-world evidence above and by user/editor feedback on
-   which current hints still feel noisy in practice.
-7. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
-   `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize
-   generalizing same-name suppression to type hints (rule #6), then (lower priority)
-   `extern`/P-Invoke parameter names (rule #7).
-8. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
-   rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
+6. ✅ **Done.** Implement rule #6 (identifier-echoes-type-name generalization) as
+   `identifierEchoesTypeName`, wired into the four identifier-bearing type-hint match arms and
+   into `validateParameter` for the parameter-name sibling, with test coverage for full-name
+   matches, last-word matches, foreach variables, and non-matching negative controls on both the
+   type-hint and parameter-hint sides.
+7. Design session to enumerate the exact suppression rule for the one remaining candidate (rule
+   #7 in the "Net takeaway" ranking — `extern`/P-Invoke parameter names — plus any of the
+   lower-priority/subjective ideas from "Candidate Ideas Gathered So Far" worth reconsidering),
+   informed by the real-world evidence above and by user/editor feedback on which current hints
+   still feel noisy in practice.
+8. Implement the agreed predicate(s) in `toInlayHint`, with unit/integration test coverage
+   (positive case: hint suppressed; negative case: hint still shown for the non-redundant
    variant) — extend the existing `InlayHintTests.fs` / `InlayHintTest.cs` fixture rather than
    creating new ones, so all rules stay exercised against one file.
 9. Decide on and (if wanted) implement the configuration angle above.
@@ -738,6 +756,6 @@ built-in suppression heuristics is also to be decided during design.
 
 | File | Likely Change |
 |------|----------------|
-| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1–#5 already landed/closed) |
-| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1–#5 already covered) |
+| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicate to `toInlayHint`'s match arms, per the design once finalized (rules #1–#6 already landed/closed) |
+| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage for the remaining rule (rules #1–#6 already covered) |
 | `tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs` | Extend with new code shapes per remaining rule |

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -42,7 +42,15 @@ to keep extending for further rules without touching other tests):
   (`hasUninformativeParameterName`), while `format:` (not numbered-suffix) correctly stays. The
   broader originally-proposed heuristic (parse the format string's `{n}` placeholders) turned out
   to be unnecessary for the evidence gathered.
-- Rules #5–#7 below are not yet implemented.
+- ✅ **Rule #5 (generic-invocation-redundant `var` type hints)** — `validateType`'s result is now
+  filtered by `isTypeSpelledOutInGenericInvocation`, which suppresses the `var` type hint when the
+  initializer is a generic invocation (qualified, e.g. `Enum.Parse<T>()`, or unqualified, e.g. a
+  local `CreateLocal<T>()`) whose explicit type-argument list contains a type symbol-equal to the
+  inferred variable type. Compares by resolved symbol rather than by name, so it correctly does
+  *not* fire when the invocation's return type differs from its type argument (e.g. a hypothetical
+  `Describe<Widget>(...)` returning `string` keeps its `: string` hint). Covered by a test using
+  the plan's own real BCL example, `Enum.Parse<DayOfWeek>(...)`.
+- Rules #6–#7 below are not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -661,9 +669,13 @@ first, ranked roughly by combined volume, confidence, and implementation risk:
    overload shape that `arg0`/`arg1`/`arg2` are already caught by rule #2's numbered-suffix
    pattern — the broader originally-proposed heuristic (parsing `{n}` placeholders out of the
    format string) wasn't needed.
-5. Suppress `var` type hints when the initializer is a generic invocation whose explicit
-   type-argument list already contains the exact inferred type (e.g. `Enum.Parse<T>()`,
-   `JsonSerializer.Deserialize<T>()`) — concrete, low-risk, no allow-list needed.
+5. **✅ Implemented.** Suppress `var` type hints when the initializer is a generic invocation whose
+   explicit type-argument list already contains the exact inferred type (e.g. `Enum.Parse<T>()`,
+   `JsonSerializer.Deserialize<T>()`) — concrete, low-risk, no allow-list needed. Implemented as
+   `isTypeSpelledOutInGenericInvocation`, comparing by resolved symbol (not name), so it covers
+   both qualified (`Enum.Parse<T>()`) and unqualified (a local generic factory method) call shapes
+   without a per-method allow-list, and correctly keeps the hint when the invocation's return type
+   differs from its type argument (confirmed via a `Describe<Widget>(...) : string` test).
 6. Generalize the existing same-name suppression (`validateParameter`) to type hints
    (`validateType`): suppress when the declared variable's identifier is a case-insensitive
    match — full or suffix — of the inferred type's name (and, per this sample, consider the same
@@ -703,24 +715,29 @@ built-in suppression heuristics is also to be decided during design.
 4. ✅ **Done.** Verify rule #4 (composite-format-string positional arguments) against a
    `log4net`-shaped `DebugFormat(format, arg0, arg1, arg2)` test — confirmed it's fully subsumed by
    rule #2's numbered-suffix pattern; closed out with no separate implementation.
-5. Design session to enumerate the exact suppression rules for the remaining candidates (rules
-   #5–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
+5. ✅ **Done.** Implement rule #5 (generic-invocation-redundant `var` hints) as
+   `isTypeSpelledOutInGenericInvocation`, filtering `validateType`'s result in the
+   `VariableDeclarationSyntax` match arm, with test coverage for qualified/unqualified matching
+   invocations, a non-matching-return-type negative control, and the plan's own
+   `Enum.Parse<DayOfWeek>(...)` example.
+6. Design session to enumerate the exact suppression rules for the remaining candidates (rules
+   #6–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
    Gathered So Far"), informed by the real-world evidence above and by user/editor feedback on
    which current hints still feel noisy in practice.
-6. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
-   `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize, in order:
-   generic-type-argument-redundant `var` hints (rule #5), generalizing same-name suppression to
-   type hints (rule #6), and (lower priority) `extern`/P-Invoke parameter names (rule #7).
-7. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
+7. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
+   `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize
+   generalizing same-name suppression to type hints (rule #6), then (lower priority)
+   `extern`/P-Invoke parameter names (rule #7).
+8. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
    rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
    variant) — extend the existing `InlayHintTests.fs` / `InlayHintTest.cs` fixture rather than
    creating new ones, so all rules stay exercised against one file.
-8. Decide on and (if wanted) implement the configuration angle above.
+9. Decide on and (if wanted) implement the configuration angle above.
 
 ## Files Likely Touched
 
 | File | Likely Change |
 |------|----------------|
-| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1–#4 already landed/closed) |
-| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1–#4 already covered) |
+| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1–#5 already landed/closed) |
+| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1–#5 already covered) |
 | `tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs` | Extend with new code shapes per remaining rule |

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1,0 +1,111 @@
+# Reducing Superfluous Inlay Hints
+
+**Status:** Design not started — this file is a placeholder to hold scope and candidate ideas
+until the exact suppression rules are worked out.
+
+**Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
+function.
+
+---
+
+## Problem Statement
+
+`InlayHint.fs` currently emits two kinds of hints with essentially no "is this hint actually
+useful to the reader" heuristics:
+
+- **Type hints** (`InlayHintKind.Type`) — for `var` declarations, deconstruction designations,
+  `foreach` loop variables, implicit lambda parameters, and `new(...)` implicit object creation.
+  The only filtering applied today is `validateType`, which suppresses a hint solely when the
+  type fails to resolve (`IErrorTypeSymbol`) or is literally named `"var"`. It does **not**
+  consider whether the type is already obvious from the surrounding code.
+- **Parameter name hints** (`InlayHintKind.Parameter`) — for positional call-site arguments.
+  The only filtering applied today is `validateParameter`, which suppresses a hint for indexers,
+  for parameters with an empty name, or when the argument text already matches the parameter
+  name case-insensitively.
+
+Both kinds of hints can currently be shown in situations where the information they convey is
+redundant, adding visual noise without value. The existing TODO comment in the file already
+flags this generally:
+
+> `// TODO: Support the configuration whether or not to show some kinds of inlay hints.`
+
+## Goal
+
+Suppress inlay hints in cases where they are superfluous — i.e. where the hidden information is
+already apparent from context — while keeping hints in the cases where they genuinely aid
+readability (untyped literals, ambiguous overloads, non-obvious inferred types, etc.).
+
+## Explicitly Out of Scope (for now)
+
+The **exact suppression rules** (which syntactic/semantic patterns count as "apparent from
+context", for both type hints and parameter hints) are **not decided yet** and will be defined in
+a follow-up design pass. This file exists to track the goal and hold candidate ideas gathered so
+far; it should be expanded into a full design (with a rule table and implementation plan, mirroring
+the style of `plans/analyzer-support.md`) before implementation starts.
+
+## Candidate Ideas Gathered So Far (unconfirmed, subject to change)
+
+These are starting points for the design discussion, not a final rule set.
+
+### Type hints — suppress when type is apparent from the initializer
+
+For `var` declarations where the right-hand side already makes the type obvious to the reader,
+the type inlay hint may be redundant:
+
+```csharp
+var someValue = getIntAbove10();  // showing `: int` here may add no value
+```
+
+Roslyn's own `CSharpInlineTypeHintsService` has a similar suppression heuristic worth reviewing as
+prior art, keyed off the shape of the initializer expression, e.g.:
+
+- `InvocationExpressionSyntax` — method/delegate call (`getIntAbove10()`)
+- `ObjectCreationExpressionSyntax` — `new Foo(...)`
+- `CastExpressionSyntax` — `(int)x`
+- `LiteralExpressionSyntax` — `42`, `"hi"`, `true`, `null`
+- `DefaultExpressionSyntax` — `default(T)` / `default`
+- `TypeOfExpressionSyntax` — `typeof(T)`
+- `SizeOfExpressionSyntax` — `sizeof(T)`
+- `BinaryExpressionSyntax` with `AsExpression` kind — `expr as T`
+- `ParenthesizedExpressionSyntax` — recurse into inner expression
+
+Whether all, some, or none of these should suppress the hint (and whether the same treatment
+should extend to `DeclarationExpressionSyntax`, `SingleVariableDesignationSyntax`, and
+`ForEachStatementSyntax` initializers) is an open design question — Roslyn's IDE hints and an LSP
+client's needs are not necessarily identical (e.g. terminal/TUI clients without hover support may
+want more hints kept, not fewer).
+
+### Parameter hints — other possible redundancy cases to consider
+
+Not yet investigated in detail, but worth putting on the table for the design pass:
+
+- Single-parameter calls where the parameter name duplicates the method name or is otherwise
+  low-information (e.g. `value`, `obj`).
+- Calls where every argument already gets a hint (dense hinting) vs. only hinting "surprising"
+  positions (e.g. boolean literals, which Roslyn's own heuristics treat specially).
+
+## Configuration Angle
+
+A related (but separate) axis is **making hint kinds configurable** (per the existing TODO
+comment), so users/editors can opt in/out of type hints, parameter hints, or specific sub-cases
+independently of any built-in suppression heuristics. Whether this ships alongside or instead of
+built-in suppression heuristics is also to be decided during design.
+
+## Next Steps
+
+1. Design session to enumerate the exact suppression rules per hint kind (type vs. parameter),
+   informed by the candidates above and by user/editor feedback on which current hints feel
+   noisy in practice.
+2. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
+   `validateType` / `validateParameter` predicates already in `InlayHint.fs`.
+3. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
+   rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
+   variant).
+4. Decide on and (if wanted) implement the configuration angle above.
+
+## Files Likely Touched
+
+| File | Likely Change |
+|------|----------------|
+| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add suppression predicates to `toInlayHint`'s match arms, per the design once finalized |
+| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` (if present) or a new test file | Add positive/negative coverage per rule |

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -23,7 +23,15 @@ to keep extending for further rules without touching other tests):
   Deliberately narrower than the original per-method-allow-list idea (it does *not* catch
   `Math.Round`'s `decimals`/`mode`, only `d`) — see the rule's doc comment in `InlayHint.fs` for
   the rationale.
-- Rules #3–#7 below are not yet implemented.
+- ✅ **Rule #3 (single lambda-argument calls)** — `validateParameter` now suppresses the hint for
+  the sole argument of a call when that argument is a lambda expression, regardless of the
+  parameter's own name — covers both LINQ (`Where(predicate)`, `Select(selector)`, …) and other
+  fluent/ORM APIs (NHibernate-style `Fetch(relatedObjectSelector)`/`ThenFetch(...)`). Deliberately
+  scoped to single-argument calls (multi-lambda-argument calls like `Combine(first, second)` keep
+  both hints) and to lambda expressions specifically (a method-group argument, e.g.
+  `Where(IsPositive)`, is out of scope and keeps its hint) — both scoping decisions are covered by
+  dedicated negative-control tests.
+- Rules #4–#7 below are not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -624,10 +632,14 @@ first, ranked roughly by combined volume, confidence, and implementation risk:
    Note: intentionally doesn't catch every opaque BCL name this way (e.g. `Math.Round`'s
    `decimals`/`mode` are kept, only `d` is suppressed) — a per-method allow-list would catch more
    but was deferred as higher-risk/higher-maintenance.
-3. Suppress parameter-name hints for single lambda/expression-typed arguments passed to methods
-   whose own name already conveys the lambda's role and which have no ambiguous overload —
-   generalized from "well-known `System.Linq` methods" to also cover other fluent/ORM APIs (e.g.
-   NHibernate's `Fetch`/`ThenFetch`).
+3. **✅ Implemented.** Suppress parameter-name hints for single lambda/expression-typed arguments
+   passed to methods whose own name already conveys the lambda's role and which have no ambiguous
+   overload — generalized from "well-known `System.Linq` methods" to also cover other fluent/ORM
+   APIs (e.g. NHibernate's `Fetch`/`ThenFetch`). Implemented as a syntactic check (sole argument of
+   the call is a `LambdaExpressionSyntax`) rather than a method allow-list, so it covers any
+   fluent/ORM API with this shape for free. Confirmed via tests that it doesn't fire on
+   multi-lambda-argument calls (e.g. a hypothetical `Combine(first, second)`) or on method-group
+   arguments (e.g. `Where(IsPositive)`), both of which keep their hints.
 4. Suppress parameter-name hints for arguments following a composite-format string literal
    (`{0}`/`{1}`/... placeholders) on formatting/logging-style method calls (this may now be fully
    subsumed by rule #2's numbered-suffix pattern, since `arg0`/`arg1`/`arg2` match it directly).
@@ -666,27 +678,29 @@ built-in suppression heuristics is also to be decided during design.
 2. ✅ **Done.** Implement rule #2 (short / numbered-suffix parameter names) as
    `hasUninformativeParameterName` in `validateParameter`, with test coverage including the
    `string.Substring`/`Stream.Write(buffer, offset, count)`-style negative controls.
-3. Design session to enumerate the exact suppression rules for the remaining candidates (rules
-   #3–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
+3. ✅ **Done.** Implement rule #3 (single lambda-argument calls) as a new `validateParameter`
+   match arm keyed on `argList.Arguments.Count = 1 && (argExpr :? LambdaExpressionSyntax)`, with
+   test coverage for the multi-lambda-argument and method-group-argument negative controls.
+4. Design session to enumerate the exact suppression rules for the remaining candidates (rules
+   #4–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
    Gathered So Far"), informed by the real-world evidence above and by user/editor feedback on
    which current hints still feel noisy in practice.
-4. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
+5. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
    `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize, in order:
-   LINQ-and-friends single-lambda parameter names (rule #3), composite-format-string positional
-   arguments (rule #4 — likely already subsumed by rule #2's numbered-suffix pattern; verify and
-   close out if so), generic-type-argument-redundant `var` hints (rule #5), generalizing same-name
-   suppression to type hints (rule #6), and (lower priority) `extern`/P-Invoke parameter names
-   (rule #7).
-5. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
+   composite-format-string positional arguments (rule #4 — likely already subsumed by rule #2's
+   numbered-suffix pattern; verify and close out if so), generic-type-argument-redundant `var`
+   hints (rule #5), generalizing same-name suppression to type hints (rule #6), and (lower
+   priority) `extern`/P-Invoke parameter names (rule #7).
+6. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
    rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
    variant) — extend the existing `InlayHintTests.fs` / `InlayHintTest.cs` fixture rather than
    creating new ones, so all rules stay exercised against one file.
-6. Decide on and (if wanted) implement the configuration angle above.
+7. Decide on and (if wanted) implement the configuration angle above.
 
 ## Files Likely Touched
 
 | File | Likely Change |
 |------|----------------|
-| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1 and #2 already landed) |
-| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1 and #2 already covered) |
+| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1–#3 already landed) |
+| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1–#3 already covered) |
 | `tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs` | Extend with new code shapes per remaining rule |

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -83,6 +83,29 @@ to keep extending for further rules without touching other tests):
   the plain-constructor shape (`new Widget()`) and the object-initializer shape (`new
   WidgetWithProperty { Value = 1 }`, mirroring the real `{ Product = ..., Warehouse = ..., ... }`
   shape from the log).
+- ✅ **New rule (sole "value" parameter)** — prompted by a third real `csharp-ls-rpc.log` example,
+  `validStatusList.Contains(this.Order.Status)`, which showed a `value:` hint even though
+  `Contains`'s own name already conveys the sole argument's role just as clearly as a lambda does
+  for `Where`/`Select` (rule #3). Rather than adding `value` to the always-on
+  `genericParameterNames` set (which risked regressing genuinely-disambiguating multi-argument
+  cases like `Dictionary<TKey, TValue>.Add(key, value)`), extended rule #3's existing
+  sole-(effective-)argument match arm in `validateParameter` to also fire when the parameter's own
+  name is in a new, narrower `soleArgumentGenericParameterNames` set (currently just `{ "value" }`)
+  -- so it only suppresses when there's truly nothing left to disambiguate. Covered by a positive
+  test (`Contains(value)`) and a negative control confirming a two-argument call keeps both hints
+  (`Add(key, value)`).
+- ✅ **New rule (static-invocation-qualifier-redundant `var` type hints)** — prompted by a fourth
+  real `csharp-ls-rpc.log` example, `var reason = string.Format(...)`, which showed a `: string?`
+  hint even though the type is spelled out immediately to the left, as the invocation's own
+  qualifier. This is rule #5's sibling for a plain (non-generic) static invocation: added
+  `isTypeSpelledOutInStaticInvocationQualifier`, which suppresses the `var` type hint when the
+  initializer's invocation is qualified by a member access whose qualifier resolves (via
+  `GetSymbolInfo`, since a type-as-qualifier has no "value type" of its own) to a type symbol-equal
+  to the inferred variable type (`string.Format(...)`, `Guid.NewGuid()`, `int.Parse(...)`, ...).
+  Compares by symbol, so it correctly doesn't fire when the qualifier is an unrelated type (e.g.
+  `Convert.ToInt32(...)`, qualifier `Convert` vs. return type `int`) or an instance (whose
+  qualifier symbol is a local/field/property, never a type). Covered by a matching positive/negative
+  test pair.
 - Rule #7 below is not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1,7 +1,12 @@
 # Reducing Superfluous Inlay Hints
 
-**Status:** Design not started — this file is a placeholder to hold scope and candidate ideas
-until the exact suppression rules are worked out.
+**Status:** Design not started, but now informed by six real-world samples (an MVC controller, two
+large business-logic "ops" classes, a companion pair of MVC controller files, a small API
+controller, and a diverse batch spanning a controller/file-I/O utility/Win32 interop/message
+handler) — see the "Real-World Evidence" sections below for concrete label-frequency data pulled
+from a live `csharp-ls-rpc.log` session, plus a source-level root-cause diagnosis of the same-name
+suppression gap (from reading `InlayHint.fs` directly). Exact suppression rules are still not
+finalized, but the same-name gap now has a concrete, actionable fix proposal.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -84,6 +89,546 @@ Not yet investigated in detail, but worth putting on the table for the design pa
 - Calls where every argument already gets a hint (dense hinting) vs. only hinting "surprising"
   positions (e.g. boolean literals, which Roslyn's own heuristics treat specially).
 
+## Real-World Evidence: Sample MVC Controller
+
+Captured from a local RPC trace of a real editor session against an unrelated private codebase
+(details anonymized below; only the structural pattern matters) — the `textDocument/inlayHint`
+responses for a stretch of ~150 lines covering five near-identical MVC actions, all following the
+same `this.WithResourceAsync(resourceName, async (resourceOps, resource) => { ... })` idiom (a
+shared `BaseController` helper that loads a resource by name and hands the caller an ops/context
+pair). Label frequency across that single response (~230 hints for ~150 lines of code):
+
+| Label | Count | Kind |
+|---|---|---|
+| `predicate:` | 58 | Parameter |
+| `selector:` | 21 | Parameter |
+| `asyncOp:` | 21 | Parameter |
+| `: DBEntity` / `: DBEntity?` | 21 | Type |
+| `: EntityOps?` | 20 | Type |
+| `: ResourceOps` | 19 | Type |
+| `: DBResource` | 19 | Type |
+| `resourceName:` | 17 | Parameter |
+| `: EntityTranslationViewModel` | 16 | Type |
+| `value:` | 13 | Parameter |
+| `savedTranslations:` / `routeValues:` / `availableLanguages:` / `actionName:` | 12 each | Parameter |
+| `: EntityNode` | 12 | Type |
+| (long tail of narrower types/params) | ≤10 each | — |
+
+Cross-referencing these against the actual source lines surfaces a few concrete, recurring
+patterns — much sharper than the abstract candidates above:
+
+1. **LINQ combinator parameter names dominate the noise (`predicate:` + `selector:` = 79 of
+   ~230 hints, >1/3 of the total).** Every `.Where(x => ...)`, `.Select(x => ...)`,
+   `.Single(x => ...)`, `.SingleOrDefault(x => ...)` call gets a parameter-name hint whose label
+   is generic BCL boilerplate (`predicate`, `selector`) carrying zero information beyond "this is
+   a lambda passed to a LINQ method" — which is already obvious from the method name itself
+   (`Where` → predicate, `Select` → selector). This is the single biggest win available and maps
+   directly to the "low-information parameter name" candidate already in this file, just with
+   real numbers behind it now.
+
+2. **The repeated callback-shape idiom re-teaches the same fact every time.** The
+   `WithResourceAsync(resourceName, async (resourceOps, resource) => {...})` pattern appears 5
+   times in this one file alone (and is presumably repeated across most controllers in the same
+   codebase, given the helper lives on a shared base controller). Each occurrence re-hints the
+   lambda parameter types (`: ResourceOps`, `: DBResource` — 19 each) and the `asyncOp:` parameter
+   name (21 times) identically. There's no per-call variation for a reader to gain from
+   repetition — once the shape is known, every subsequent occurrence is pure noise. This is a case
+   the current candidate list doesn't call out explicitly: **suppress-on-repetition /
+   suppress-for-idiomatic, fixed-signature callbacks**, not just suppress-on-initializer-shape.
+
+3. **Found a likely gap in the existing same-name suppression, not just a design question.**
+   `resourceName:` fires 17 times on calls of the shape `WithResourceAsync(resourceName, ...)`.
+   Checked the shared helper's actual signature and confirmed the shape is:
+
+   ```fsharp
+   public async Task<IActionResult> WithResourceAsync(
+       string resourceName,
+       Func<ResourceOps, DBResource, Task<IActionResult>> asyncOp,
+       ...)
+   ```
+
+   The parameter is literally named `resourceName` and every call site passes a local/parameter
+   also literally named `resourceName` — an exact, same-case identifier match, which
+   `validateParameter`'s existing "argument text matches parameter name case-insensitively" rule
+   should already suppress. It doesn't, here. Worth a standalone investigation (likely a separate
+   bug fix, independent of the broader suppression-design work) into why this exact-match case
+   isn't being caught — e.g. is the argument wrapped in something (implicit conversion node?)
+   that defeats the current text-comparison logic in `toInlayHint`/`validateParameter`?
+
+4. **ASP.NET idioms self-describe via call shape.** `actionName:` / `routeValues:` (12 each) hint
+   every `RedirectToAction(nameof(SomeAction), new { a, b })` call. The combination of `nameof(...)`
+   as first arg and an anonymous object as second arg is an extremely well-known, unambiguous MVC
+   idiom — a case where the *shape of a specific, recognizable call pattern* (not just the
+   initializer shape of a `var`) makes the hint redundant. Same reasoning likely applies to other
+   framework idioms beyond `RedirectToAction` (worth enumerating during design).
+
+5. **Type hints on `var` from method calls are the most defensible of the bunch, but still
+   repetitive.** `: DBEntity?`, `: EntityOps?`, `: EntityNode` etc. (all from
+   `var x = someCollection.Single(...)` / `.GetChild(...)` style calls) aren't obvious from the
+   call alone — you'd need to know the return type of the accessor/the element type of the
+   collection. These look like legitimate keeps under the "initializer shape" heuristic
+   (`InvocationExpressionSyntax` doesn't make the type obvious here, unlike e.g. `new Foo()`).
+   The volume is high mostly *because* the same call idiom (`entity = ...Single(...)`,
+   `entityOps = ...GetChild(...)`) is repeated in every action, not because any individual hint
+   is wrong.
+
+6. **Misc low-information single-arg parameter names**: `value:` (13), plus a couple of similar
+   domain-specific single-arg names each occurring a handful of times — single-parameter
+   update/setter-style calls where the parameter name is generic and adds little beyond what the
+   call site already conveys positionally.
+
+## Real-World Evidence: Business-Logic ("Ops") Class Sample
+
+A second sample, from a large (~6,500 line) business-logic class in the same private codebase —
+this time a plain C# service/"ops" class (no MVC, mostly synchronous/async domain methods,
+logging, and validation), sampled across ~1,800 lines via 14 separate `inlayHint` requests,
+de-duplicated by position. 366 unique hints total. Top labels:
+
+| Label | Count | Kind |
+|---|---|---|
+| `format:` | 47 | Parameter |
+| `arg0:` | 45 | Parameter |
+| `predicate:` | 29 | Parameter |
+| `arg1:` | 24 | Parameter |
+| `: DBResourceDocument` | 17 | Type |
+| `: Timing?` | 15 | Type |
+| `name:` | 15 | Parameter |
+| `: ResourceStatus` | 11 | Type |
+| `message:` | 11 | Parameter |
+| `db:` | 11 | Parameter |
+| `proxy:` | 11 | Parameter |
+| `: DBResourceItem` | 9 | Type |
+| `flag:` | 8 | Parameter |
+| `arg2:` | 6 | Parameter |
+| `selector:` | 6 | Parameter |
+| `: ResourceCondition` | 5 | Type |
+| (long tail) | ≤4 each | — |
+
+This file surfaces two patterns not visible in the controller sample, plus reinforces two from
+before:
+
+1. **Format-string positional-argument hints are the single biggest category here — bigger than
+   LINQ names.** `format:` + `arg0:` + `arg1:` + `arg2:` = 122 of 366 hints (~1/3 of the total),
+   all from calls of the shape:
+
+   ```csharp
+   Logger.DebugFormat(
+       "{0}: cannot do the thing; reason",
+       nameof(SomeMethodAsync));
+   ```
+
+   or
+
+   ```csharp
+   throw new ResourceOpException(
+       string.Format(
+           "{0}: mode could not be set to `{1}`: {2}",
+           nameof(this.SetModeAsync), mode, modeChangeCondition));
+   ```
+
+   These are arguably the single clearest redundant-parameter-hint case found across both
+   samples: the format string itself already spells out the positional correspondence via
+   `{0}`, `{1}`, `{2}` placeholders, so labeling the arguments `format:`/`arg0:`/`arg1:`/`arg2:`
+   adds strictly zero information beyond what's already visible in the preceding string literal.
+   **Candidate rule:** suppress parameter-name hints for arguments following a composite/format
+   string parameter on well-known formatting methods (`string.Format`, `*.DebugFormat`,
+   `*.InfoFormat`, `*.ErrorFormat`, `string.Join`-adjacent, or more generally any method whose
+   preceding string-literal argument contains `{n}`-style placeholders).
+
+2. **New rule candidate: the local variable's own name already spells out the type name.**
+   Confirmed concrete cases:
+
+   ```csharp
+   var resourceStatus = this.Resource.Status;  // hint: ": ResourceStatus"
+   ```
+
+   ```csharp
+   public async Task<ResourceCondition> CanSetModeAsync(ResourceMode mode)
+   {
+       var settingChangeCondition = await this.CanChangeSettingsAsync();  // hint: ": ResourceCondition"
+       ...
+   ```
+
+   In the first case the variable identifier is a case-insensitive match of the *entire* type
+   name (`resourceStatus` ↔ `ResourceStatus`). In the second, the variable name's suffix
+   (`...Condition`) already matches the type name (`ResourceCondition`). This is the type-hint
+   analogue of the same-name suppression rule `validateParameter` already applies to parameter
+   hints — it just hasn't been generalized to `validateType` yet. Given how idiomatic this naming
+   style is in this codebase (and probably others — `xyzStatus`/`xyzCondition`/`xyzResult`-style
+   locals are a common C# convention), this looks like a high-value, low-risk rule to add
+   alongside the LINQ and format-string ones.
+
+3. **The repeated profiling/scope idiom reinforces the earlier "suppress fixed-signature,
+   repeated callback/idiom" finding, at even higher volume.** `: Timing?` (15) + `name:` (15) come
+   entirely from a one-line profiling-scope idiom (`using var scope = Profiler.Current.Step(nameof(SomeMethodAsync));`)
+   that opens nearly every public method in the file. Same shape, same labels, dozens of times —
+   arguably the strongest case yet for a "don't re-hint an idiom you've already hinted
+   identically N times in this file/session" rule, if such a stateful heuristic is in scope.
+
+4. **Single string-literal exception/log messages (`message:`, 11) reinforce the earlier
+   "low-information single-arg parameter name" finding** — e.g. `throw new ResourceOpException("cannot enter status X")`.
+   The only sensible parameter for a custom exception's sole string argument is its message; the
+   hint adds nothing a reader doesn't already know from the fact that it's a string literal being
+   thrown.
+
+## Real-World Evidence: Third Sample (Large Business-Logic Class, ~3,000 Lines)
+
+A third sample, from another large business-logic "ops" class in the same private codebase,
+sampled across nearly the entire ~3,000-line file via 46 `inlayHint` requests, de-duplicated by
+position: 975 unique hints. Top labels:
+
+| Label | Count | Kind |
+|---|---|---|
+| `predicate:` | 76 | Parameter |
+| `selector:` | 53 | Parameter |
+| `message:` | 40 | Parameter |
+| `value:` | 36 | Parameter |
+| `db:` | 31 | Parameter |
+| `obj:` | 22 | Parameter |
+| `format:` | 22 | Parameter |
+| `arg0:` | 20 | Parameter |
+| `arg1:` | 16 | Parameter |
+| `item:` | 14 | Parameter |
+| `proxy:` | 13 | Parameter |
+| `paramName:` | 11 | Parameter |
+| `d:` | 10 | Parameter |
+| `arg2:` | 9 | Parameter |
+| `decimals:` | 8 | Parameter |
+| `val1:` / `val2:` | 6 each | Parameter |
+| (long tail of narrower types/params) | ≤17 each | — |
+
+This sample reinforces the LINQ (`predicate:`/`selector:` = 129, the biggest category yet) and
+format-string (`format:`/`arg0:`/`arg1:`/`arg2:` = 67) findings from the previous two samples at
+even higher volume, and surfaces two genuinely new points:
+
+1. **Even the .NET BCL itself ships famously opaque parameter names — and the hints faithfully
+   reproduce them.** Confirmed concrete cases:
+
+   ```csharp
+   decimal computedVatAmount = Math.Round(
+       computedVatAmountForDelivery + computedVatAmountForItems,
+       2,
+       MidpointRounding.AwayFromZero);
+   ```
+   → hints `d:` and `decimals:` on the first two arguments (`Math.Round`'s real parameter names
+   are literally `d` and `decimals`).
+
+   ```csharp
+   return Math.Min(100, Math.Max(0, parsedValue));
+   ```
+   → hints `val1:`/`val2:` on *both* the outer `Math.Min` and inner `Math.Max` calls
+   (`Math.Min`/`Math.Max`'s real parameter names are literally `val1`/`val2`).
+
+   These are arguably a stronger suppression candidate than the LINQ case: they're tied to a
+   small, enumerable list of extremely common, well-known BCL methods (`Math.Round`, `Math.Min`,
+   `Math.Max`, and likely similar ones worth auditing) whose own parameter names are so generic
+   they need a name *for* the parameter name — a hint here can't possibly help a reader, only
+   clutter. Unlike the fuzzier heuristics above, this could ship as a small, static allow-list
+   with essentially zero risk of suppressing a genuinely useful hint.
+
+2. **Counter-example found — not every well-known BCL method should lose its hints.** In the same
+   file:
+
+   ```csharp
+   var bank = bankAccount.Substring(4, bankAccount.Length - 4) + bankAccount.Substring(0, 4);
+   ```
+   → hints `startIndex:`/`length:` on `string.Substring(int startIndex, int length)`. Unlike
+   `Math.Round`/`Math.Min`/`Math.Max`, these parameter names are genuinely informative — two
+   same-typed (`int`) positional arguments where transposing them is a real, easy, silent bug.
+   This is exactly the kind of hint that should be *kept*. It's a useful reminder that "well-known
+   BCL method" alone isn't a sufficient signal for suppression — it has to be combined with
+   "the parameter names themselves are uninformative," which has to be judged per-method (or at
+   minimum per a curated allow-list), not derived from a generic rule like method popularity or
+   argument-type sameness alone.
+
+3. **New UX nuance, orthogonal to redundancy: anonymous-type hints can be very long.** Found a
+   hint whose label was the full shape of a multi-field anonymous type (7 occurrences), e.g.
+   `: <anonymous type: int Year, int Month, ..., int InvoiceCount>` — presumably from a grouped/
+   aggregated LINQ projection assigned to `var`. The *information* here isn't redundant (anonymous
+   types have no name to look up any other way), so this isn't a suppression candidate under the
+   framework this doc has used so far. But the sheer rendered length is its own distinct
+   complaint — worth tracking separately as a possible follow-up (e.g. truncating/eliding
+   anonymous-type hints beyond N members) rather than folding it into the suppress/keep binary.
+
+## Real-World Evidence: Fourth Sample (MVC Controller, Two Companion Files)
+
+A fourth sample, from two companion partial-class files of one MVC controller in the same private
+codebase (an "account details" controller and its "order details" sub-view counterpart — the
+same controller class split across two files by feature). 307 unique hints from the first file,
+781 from the second (de-duplicated by position). Top labels combined:
+
+| Label | Count | Kind |
+|---|---|---|
+| `selector:` | 50 | Parameter |
+| `predicate:` | 43 | Parameter |
+| `value:` | 35 | Parameter |
+| `timestamp:` | 20 | Parameter |
+| `name:` | 20 | Parameter |
+| `keySelector:` | 17 | Parameter |
+| `user:` | 17 | Parameter |
+| `: Timing?` | 14 | Type |
+| `relatedObjectSelector:` | 10 | Parameter |
+| `expression:` / `errorMessage:` | 10 each | Parameter |
+| `d:` / `decimals:` | 10 each | Parameter |
+| `mode:` | 9 | Parameter |
+| `actionName:` / `routeValues:` | 8 each | Parameter |
+| `viewName:` / `model:` | 6 / 7 | Parameter |
+| (long tail incl. single-letter names `s:`, `k:`, `l:`) | ≤10 each | Parameter |
+
+Alongside reinforcing every finding from the first three samples (LINQ names, the repeated
+profiling-scope idiom, format-string args, `RedirectToAction`'s idiom), this pair of files
+surfaces three more new points:
+
+1. **A fourth confirmed instance of the "opaque BCL parameter name" pattern — plus a nuance.**
+   `Math.Round(price, decimalPlaces, MidpointRounding.AwayFromZero)`-style calls appear here too,
+   this time surfacing all three parameter names (`d:`/`decimals:`/`mode:`) rather than just the
+   first two seen in the third sample. `mode:` is a mildly more informative name than `d`/`decimals`,
+   but is still arguably redundant here specifically *because* the argument is a fully-qualified
+   enum member access (`MidpointRounding.AwayFromZero`) — the enum's own type name already conveys
+   the meaning. **Tentative extra candidate:** suppress parameter-name hints when the argument is
+   a qualified enum-member-access expression *and* it's the sole parameter of that enum type in the
+   call — same caution as the `Substring` counter-example applies: this breaks down for calls with
+   two same-typed enum arguments where the parameter names are the only way to tell them apart.
+
+2. **The "single lambda argument, method name already says what it's for" LINQ finding
+   generalizes beyond `System.Linq`.** `relatedObjectSelector:` (10 occurrences, often repeated
+   identically down a chain of consecutive lines) comes from NHibernate's fluent eager-loading API:
+
+   ```csharp
+   .Fetch(x => x.RelatedEntity).ThenFetch(y => y.SubEntity)
+   .Fetch(x => x.RelatedEntity).ThenFetch(y => y.OtherSubEntity)
+   ```
+
+   Exactly the same shape as LINQ's `Where`/`Select`: a single lambda argument whose role is
+   already fully conveyed by the enclosing method's own name (`Fetch`/`ThenFetch`). This suggests
+   rule #2 in the running list below should be phrased more generally — "single lambda/expression
+   parameter, unambiguous overload, method name conveys role" — rather than hard-coded to
+   `System.Linq`, so it also naturally covers other fluent/ORM-style APIs.
+
+3. **Single/near-single-character parameter names recur widely, on both BCL and user-defined
+   methods** — `d:`, `s:`, `k:`, `l:` all appear as real parameter-name hints in this pair of
+   files (the last three from ordinary user-defined helper methods, not BCL). This broadens the
+   "opaque BCL parameter name" allow-list idea (finding #1 from the third sample) into a
+   potentially simpler, more general, method-agnostic heuristic: **a parameter name of length ≤ 1–2
+   characters is essentially never informative as a hint, regardless of which method (BCL or
+   user-defined) it belongs to** — likely cheaper to implement and higher-coverage than maintaining
+   a hand-curated per-method allow-list, though it should be validated against real cases before
+   committing (e.g. does a 2-letter abbreviation ever meaningfully disambiguate two same-typed
+   args better than nothing?).
+
+## Real-World Evidence: Fifth Sample (Small API Controller, ~210 Lines)
+
+A fifth, much smaller sample — an API controller file (~210 lines) in a different subsystem of the
+same private codebase (an auth-scoped API, not the MVC website). Only 90 unique hints total, but
+dense (roughly one hint every 2 lines), and it surfaces two clean, novel findings on top of
+reinforcing the repeated-idiom pattern at unusually high density.
+
+| Label | Count | Kind |
+|---|---|---|
+| `value:` | 7 | Parameter |
+| `: DBCategoryMapping` (illustrative name) | 6 | Type |
+| `scopeId:` (illustrative name) | 5 | Parameter |
+| `scopeCaps:` (illustrative name) | 5 | Parameter |
+| `asyncOp:` | 5 | Parameter |
+| `predicate:` | 4 | Parameter |
+| `id:` | 4 | Parameter |
+| (long tail incl. 2 tuple/anonymous-type hints, ≤3 each) | ≤3 each | — |
+
+1. **A third confirmed instance of the repeated fixed-signature callback idiom — at very high
+   density, and with a second confirmed instance of the same-name suppression gap.** Every action
+   method in this file opens with:
+
+   ```csharp
+   public async Task<IActionResult> SomeAction(
+       [FromRoute] string scopeId,
+       [FromRoute] string otherId
+   ) => await this.AuthContext.WithScopeAsync(
+       scopeId,
+       AuthCaps.ReadScope,
+       async (db, scope) => { ... });
+   ```
+
+   repeated 5 times in ~210 lines (roughly once every 40 lines) — a *different* shared helper
+   (`AuthContext.WithScopeAsync`, an auth-scoping helper) than the `BaseController` one from the
+   first sample, confirming this "load-scope-then-invoke-callback" idiom is a pervasive,
+   independently-reimplemented architectural convention across the codebase, not a one-off. Each
+   occurrence re-hints `scopeId:`, `scopeCaps:`, and `asyncOp:` identically. Critically,
+   `scopeId:` fires on an argument whose local variable is *also* named `scopeId` — the exact same
+   same-name-suppression gap found in the first sample's `resourceName:` case, now reproduced a
+   second time against a completely unrelated helper method. This raises confidence that it's a
+   genuine, reproducible bug in `validateParameter`'s text-matching logic rather than a one-off
+   fluke, and that fixing it would have an outsized real-world impact given how idiomatic this
+   call shape is throughout the codebase.
+
+2. **New rule candidate: the type is already spelled out in an explicit generic type argument.**
+   ```csharp
+   var integration = Enum.Parse<IntegrationId>(integrationCode);
+   ```
+   → hint `: IntegrationId` on `integration`. But the type is already written out, verbatim, one
+   `Enum.Parse<` away from the hint itself — the reader doesn't need a hint to know the type; it's
+   sitting right there in the explicit type-argument list of the very same expression. This is a
+   concrete, low-risk, easily-specified refinement of the initializer-shape idea from the original
+   candidate list: **suppress a `var` type hint when the initializer is a generic invocation whose
+   explicit type-argument list contains the exact inferred type** — covers `Enum.Parse<T>()` and
+   similarly-shaped generic factory/parse/deserialize methods (`JsonSerializer.Deserialize<T>()`,
+   `Activator.CreateInstance<T>()`, etc.) without needing a per-method allow-list.
+
+3. **A second, different confirmation of the anonymous/tuple-type verbosity nuance.** A hint like
+   `: (string Code, string Value, string Name, string UIValue)` appears here from a named
+   `ValueTuple` literal returned out of a `.Select(...)` projection — the same "non-redundant but
+   visually heavy" complaint raised for anonymous types in the third sample, just for tuples
+   instead. Reinforces that this is worth tracking as its own (separate, length-focused) follow-up
+   regardless of which compound-type shape triggers it.
+
+## Real-World Evidence: Sixth Sample (Four Files Spanning Very Different Domains)
+
+A sixth, deliberately diverse batch: an API controller, a small low-level file-system utility
+class, a Win32 P/Invoke device-info wrapper, and a message/event-processing handler class — picked
+specifically to test whether the findings so far are specific to "MVC controller / business-logic
+ops class" code, or hold more generally. They do — every prior finding reappears — plus this batch
+surfaces several new, sharply-defined points, including (via reading `InlayHint.fs` itself) a
+concrete, high-confidence diagnosis of the same-name suppression bug's root cause.
+
+**Controller file** (~1,100 lines, 27 requests): reinforces `predicate:`/`office:`/`db:`/`user:`
+etc. at similar volumes to earlier controller samples, plus two small new points:
+`opOnOrderAsync:`/`messageDispatcherAsync:` are further confirmed instances of the "repeated
+delegate-callback-parameter" idiom (finding from sample 1), and `messageDispatcherAsync` is
+additionally an example of **a parameter name that's just a decapitalized copy of its own
+delegate type name** (`MessageDispatcherAsync` the type → `messageDispatcherAsync` the parameter)
+— a narrower, safer sibling of the "var name already spells out the type" rule (#6 below), applied
+to parameters instead of locals.
+
+**File-system utility class** (~240 lines, 63 hints): a plain, non-business-logic I/O helper —
+useful because it's dominated entirely by BCL calls, giving two more data points on the
+"well-known BCL method, good or bad parameter names?" question:
+- `new FileStream(path, FileMode.OpenOrCreate, FileAccess.Write)` (repeated identically 4 times)
+  → hints `path:`/`mode:`/`access:`. Here the *two enum-typed* arguments are of **two different
+  enum types** (`FileMode`, `FileAccess`), so — unlike the single-enum-argument `Math.Round`
+  case — there's no way to confuse them even without hints; the qualified enum member access
+  already fully disambiguates both. Cleaner support for the tentative "qualified enum member
+  access is self-describing" idea than the earlier example.
+- `file.Write(value, 0, value.Length)` (`Stream.Write(byte[] buffer, int offset, int count)`)
+  → hints `buffer:`/`offset:`/`count:`. A second confirmed "genuinely useful, don't suppress"
+  counter-example alongside `string.Substring` — `offset`/`count` are same-typed ints where mixing
+  them up is a real bug class.
+- `Path.Combine(path1, path2)` → hints `path1:`/`path2:`. A third real BCL example (after
+  `Math.Min`/`Math.Max`'s `val1`/`val2` and the format-string `arg0`/`arg1`/`arg2`) of the same
+  underlying anti-pattern: **numbered-suffix parameter names**. All three of these could collapse
+  into a *single* mechanical rule instead of three separate special cases (see rule #2 below).
+
+**Win32 P/Invoke device-info wrapper** (~270 lines, 90 hints): the most extreme evidence yet for
+short/opaque parameter names, and a wholly new category:
+- `new Guid(0x8c7ed206, 0x3f8a, 0x4827, 0xb3, 0xab, 0xae, 0x9e, 0x1f, 0xae, 0xfc, 0x6c)` → hints
+  `a:`/`b:`/`c:`/`d:`/`e:`/... — the *actual .NET BCL* `Guid` struct constructor's real parameter
+  names are single letters. About as strong a confirmation as possible of rule #1 below.
+- A native `[DllImport]`-declared method (a real Win32 SetupAPI call) is invoked identically 4
+  times, each time hinting its native-header-derived, PascalCase parameter names (`DeviceInfoSet:`,
+  `DeviceInfoData:`, `PropertyBuffer:`, `RequiredSize:`, etc.) — a **new category**: parameter
+  hints on calls to `extern`/P-Invoke-declared methods largely restate names that are meaningless
+  without the platform's own API documentation anyway (which is where a developer calling a
+  well-known native API actually looks up argument order, not the C# parameter hint), and are
+  frequently non-idiomatic verbatim copies of the native header. **Candidate rule:** suppress
+  parameter-name hints for arguments to methods marked `extern` / decorated with
+  `DllImportAttribute` (or, more conservatively, restrict this to well-known OS API DLLs).
+
+**Message/event-processing handler class** (~530 lines, 139 hints): reinforces `id:`/`message:`/
+`value:` at high volume, plus a very clean **counter-example**: `oldValue:`/`newValue:` hints on
+what's evidently a change-tracking/audit-style handler — transposing old vs. new is a serious,
+easy, silent bug class, so these hints should absolutely be *kept*, reinforcing that any
+implemented ruleset needs solid negative-case test coverage, not just positive suppression cases.
+
+### Root-Cause Analysis: The Same-Name Suppression Gap (Confirmed by Reading `InlayHint.fs`)
+
+This sample's investigation went one step further: rather than just re-observing the
+`resourceName:`/`scopeId:`-style gap a third time, we read the actual `validateParameter`
+implementation in this repo's `src/CSharpLanguageServer/Handlers/InlayHint.fs`:
+
+```fsharp
+let validateParameter (arg: SyntaxNode) (par: IParameterSymbol) =
+    match arg.Parent with
+    | :? BracketedArgumentListSyntax -> None
+    | _ when String.IsNullOrEmpty(par.Name) -> None
+    | _ when String.Equals(arg.GetText().ToString(), par.Name, StringComparison.CurrentCultureIgnoreCase) ->
+        None
+    | _ -> Some par
+```
+
+This directly explains two distinct issues found across the real-world samples:
+
+1. **Likely root cause of the `resourceName:`/`scopeId:` bug:** `arg.GetText()` returns the
+   `SyntaxNode`'s text *including its trivia* (leading/trailing whitespace, newlines) — much like
+   `ToFullString()` — rather than just its significant text. This codebase's dominant call-site
+   style puts each argument of a multi-line call on its own indented line
+   (`WithScopeAsync(\n    scopeId,\n    ...)`), so `arg.GetText()` for that `scopeId` argument
+   likely includes its leading indentation whitespace and is therefore *not* byte-equal to the
+   bare parameter name `"scopeId"`, even though the meaningful identifier text is identical —
+   causing the case-insensitive equality check to silently fail and the hint to wrongly render.
+   **Suggested fix:** compare against the argument's significant/underlying identifier text
+   instead of raw `GetText()` — e.g. match on `argument.Expression` when it's an
+   `IdentifierNameSyntax` and compare `.Identifier.ValueText`, rather than the whole node's text.
+   This is a hypothesis based on reading the code, not yet runtime-verified — worth confirming
+   with a quick unit test contrasting a single-line call vs. a multi-line indented call before
+   relying on it.
+2. **A second, structurally distinct gap, not just a trivia bug:** even with the trivia issue
+   fixed, this exact-string-match approach can *never* suppress a qualified member-access argument
+   like `this.RazorEngineService` against a parameter named `razorEngineService` — the *whole*
+   argument text (`"this.RazorEngineService"`) will never equal the bare parameter name
+   (`"razorEngineService"`), no matter the casing. This was confirmed directly against source: a
+   6-argument constructor call passing `this.RazorEngineService`, `this.LocalizationProvider`,
+   `this.Timestamp`, `this.PdfRenderer`, and `this.BlobStore` for parameters
+   `razorEngineService`, `localizationProvider`, `timestamp`, `pdfRenderer`, `blobStore`
+   (all case-insensitive exact matches once the `this.` qualifier is considered) all still get
+   hints — this is a real, common pattern (`this.Foo` arguments matching `foo` parameters in
+   constructor/DI-style calls) that the current same-name check simply isn't designed to catch.
+   **Suggested enhancement:** extend `validateParameter` to also compare the parameter name
+   against the last identifier segment of a qualified member-access expression
+   (`MemberAccessExpressionSyntax.Name.Identifier.ValueText`), not just bare identifiers.
+
+Both fixes are independent, small, and additive to the existing `validateParameter` logic — no new
+heuristic categories needed, just making the existing "don't restate what's already in the
+argument's own name" rule actually work in the two most common shapes it currently misses.
+
+**Net takeaway across all six samples:** the highest-value, lowest-risk rules to prioritize
+first, ranked roughly by combined volume, confidence, and implementation risk:
+
+1. **Fix the same-name parameter suppression gap** — now root-caused (see above) into two
+   concrete, independent, small fixes: (a) compare significant identifier text instead of raw
+   `GetText()` (likely trivia/whitespace bug), and (b) extend the match to the last segment of
+   qualified member-access arguments (`this.Foo` vs. parameter `foo`). Confirmed across three
+   samples against at least three unrelated call sites/helpers; given how idiomatic both call
+   shapes are throughout the codebase, this pair of fixes alone would likely eliminate a large
+   fraction of real-world noise, before any new heuristic work.
+2. Suppress parameter-name hints for very short (≤ 1–2 character) parameter names and for
+   numbered-suffix parameter names (`arg0`, `val1`, `path2`, i.e. matching `^\w*?\d+$`) —
+   collapses what were three separate special cases (BCL opaque names, format-string args,
+   `Math.Min`/`Max`, `Path.Combine`) into one or two simple, mechanical, method-agnostic rules.
+   Still needs the `string.Substring`/`Stream.Write(buffer, offset, count)`-style counter-example
+   check — i.e. confirm this doesn't fire on short-but-genuinely-disambiguating names.
+3. Suppress parameter-name hints for single lambda/expression-typed arguments passed to methods
+   whose own name already conveys the lambda's role and which have no ambiguous overload —
+   generalized from "well-known `System.Linq` methods" to also cover other fluent/ORM APIs (e.g.
+   NHibernate's `Fetch`/`ThenFetch`).
+4. Suppress parameter-name hints for arguments following a composite-format string literal
+   (`{0}`/`{1}`/... placeholders) on formatting/logging-style method calls (this may now be fully
+   subsumed by rule #2's numbered-suffix pattern, since `arg0`/`arg1`/`arg2` match it directly).
+5. Suppress `var` type hints when the initializer is a generic invocation whose explicit
+   type-argument list already contains the exact inferred type (e.g. `Enum.Parse<T>()`,
+   `JsonSerializer.Deserialize<T>()`) — concrete, low-risk, no allow-list needed.
+6. Generalize the existing same-name suppression (`validateParameter`) to type hints
+   (`validateType`): suppress when the declared variable's identifier is a case-insensitive
+   match — full or suffix — of the inferred type's name (and, per this sample, consider the same
+   for parameter names that are a decapitalized echo of their own type, e.g. `messageDispatcherAsync`).
+7. Consider suppressing parameter-name hints for arguments to `extern`/P-Invoke-declared methods,
+   given their names are typically non-idiomatic, verbatim native-header copies that add little
+   without external platform documentation regardless.
+
+The idiom-repetition (suppress-on-known-recurring-callback-shape), idiom-shape (e.g.
+`RedirectToAction`/`View`), qualified-enum-argument idea, and anonymous/tuple-type-verbosity ideas
+remain worth pursuing but are lower-volume, more subjective, and/or a different kind of problem
+(length vs. redundancy) than the seven above. Equally important: this sample reinforced that
+**negative test cases matter as much as positive ones** — `Stream.Write(buffer, offset, count)`
+and `oldValue`/`newValue`-style handlers are concrete, real examples where hints must be kept.
+
 ## Configuration Angle
 
 A related (but separate) axis is **making hint kinds configurable** (per the existing TODO
@@ -94,14 +639,26 @@ built-in suppression heuristics is also to be decided during design.
 ## Next Steps
 
 1. Design session to enumerate the exact suppression rules per hint kind (type vs. parameter),
-   informed by the candidates above and by user/editor feedback on which current hints feel
-   noisy in practice.
+   informed by the candidates above, the real-world evidence below, and by user/editor feedback
+   on which current hints feel noisy in practice.
 2. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
-   `validateType` / `validateParameter` predicates already in `InlayHint.fs`.
-3. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
+   `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize the seven
+   rules ranked in the combined "Net takeaway" above first, in order: the same-name suppression
+   gap fix (two concrete sub-fixes, now root-caused — see below), short/opaque and numbered-suffix
+   parameter names, LINQ-and-friends single-lambda parameter names, composite-format-string
+   positional arguments, generic-type-argument-redundant `var` hints, generalizing same-name
+   suppression to type hints, and (lower priority) `extern`/P-Invoke parameter names.
+3. Land the two same-name suppression gap fixes identified by reading `InlayHint.fs` (see
+   "Root-Cause Analysis" above): (a) compare significant identifier text rather than raw
+   `arg.GetText()` in `validateParameter` (likely a leading-trivia/whitespace bug — verify with a
+   unit test contrasting single-line vs. multi-line indented call sites before committing to this
+   as the fix), and (b) extend the same-name match to also cover the last identifier segment of
+   qualified member-access arguments (`this.Foo` vs. parameter `foo`). Both are small, additive,
+   and testable in isolation from the rest of this plan's heuristic work.
+4. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
    rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
    variant).
-4. Decide on and (if wanted) implement the configuration angle above.
+5. Decide on and (if wanted) implement the configuration angle above.
 
 ## Files Likely Touched
 

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -60,6 +60,29 @@ to keep extending for further rules without touching other tests):
   own name is a decapitalized echo of its own declared type, e.g. a `MessageDispatcherAsync
   messageDispatcherAsync` parameter). Both sides covered by matching negative-control tests where
   the identifier does *not* echo the type.
+- ✅ **New rule (generic `obj`-style parameter names)** — prompted by a real `csharp-ls-rpc.log`
+  example, `NHibernate.ISession.SaveAsync(object obj, CancellationToken cancellationToken =
+  default)` called with a single explicit argument. Neither rule #1 (argument name doesn't match
+  `obj`) nor rule #2 (`obj` is 3 characters, over the ≤2 mechanical cutoff, and not a
+  numbered-suffix shape) caught it. Added a small, explicit, easy-to-extend
+  `genericParameterNames` set (currently just `{ "obj" }`) folded into
+  `hasUninformativeParameterName`, rather than broadening the mechanical length/regex checks
+  (which risked over-suppressing other short-but-meaningful 3-letter names). Covered by a positive
+  test (`Save(object obj)`) and a negative control confirming a different, coincidentally
+  same-length parameter name (`Log(string msg)`) still keeps its hint.
+- ✅ **New rule (explicit-object-creation-redundant `var` type hints)** — prompted by a second real
+  `csharp-ls-rpc.log` example, `var whProd = new DBWarehouseProduction { ... };`, which showed a
+  `": DBWarehouseProduction?"` hint even though the type is spelled out immediately after `new` on
+  the same line. This is the plain-object-creation sibling of rule #5 (which only handles generic
+  invocations' type-argument lists): added `isTypeSpelledOutInObjectCreation`, which suppresses the
+  `var` type hint when the initializer is an explicit (non-target-typed, i.e. not `new()`)
+  `ObjectCreationExpressionSyntax` whose spelled-out type is symbol-equal to the inferred variable
+  type. Deliberately restricted to explicit `new Type(...)`/`new Type { ... }` — target-typed
+  `new()` is the genuinely useful case and is handled separately by the existing
+  `ImplicitObjectCreationExpressionSyntax` match arm, which is untouched. Covered by tests for both
+  the plain-constructor shape (`new Widget()`) and the object-initializer shape (`new
+  WidgetWithProperty { Value = 1 }`, mirroring the real `{ Product = ..., Warehouse = ..., ... }`
+  shape from the log).
 - Rule #7 below is not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
@@ -741,6 +764,13 @@ built-in suppression heuristics is also to be decided during design.
    into `validateParameter` for the parameter-name sibling, with test coverage for full-name
    matches, last-word matches, foreach variables, and non-matching negative controls on both the
    type-hint and parameter-hint sides.
+6a. ✅ **Done.** Implement the `obj`-specific generic-parameter-name rule as `genericParameterNames`
+   (folded into `hasUninformativeParameterName`), with test coverage for the positive case
+   (`Save(object obj)`) and a same-length-but-different-name negative control (`Log(string msg)`).
+6b. ✅ **Done.** Implement rule #5's plain-object-creation sibling as
+   `isTypeSpelledOutInObjectCreation`, filtering `validateType`'s result in the
+   `VariableDeclarationSyntax` match arm alongside `isTypeSpelledOutInGenericInvocation`, with test
+   coverage for both the plain-constructor and object-initializer shapes.
 7. Design session to enumerate the exact suppression rule for the one remaining candidate (rule
    #7 in the "Net takeaway" ranking — `extern`/P-Invoke parameter names — plus any of the
    lower-priority/subjective ideas from "Candidate Ideas Gathered So Far" worth reconsidering),

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1,12 +1,29 @@
 # Reducing Superfluous Inlay Hints
 
-**Status:** Design not started, but now informed by six real-world samples (an MVC controller, two
-large business-logic "ops" classes, a companion pair of MVC controller files, a small API
-controller, and a diverse batch spanning a controller/file-I/O utility/Win32 interop/message
-handler) — see the "Real-World Evidence" sections below for concrete label-frequency data pulled
-from a live `csharp-ls-rpc.log` session, plus a source-level root-cause diagnosis of the same-name
-suppression gap (from reading `InlayHint.fs` directly). Exact suppression rules are still not
-finalized, but the same-name gap now has a concrete, actionable fix proposal.
+**Status:** Full design/rule-table pass for the remaining candidates still not started, but
+informed by six real-world samples (an MVC controller, two large business-logic "ops" classes, a
+companion pair of MVC controller files, a small API controller, and a diverse batch spanning a
+controller/file-I/O utility/Win32 interop/message handler) — see the "Real-World Evidence" sections
+below for concrete label-frequency data pulled from a live `csharp-ls-rpc.log` session, plus a
+source-level root-cause diagnosis of the same-name suppression gap (from reading `InlayHint.fs`
+directly).
+
+Implementation has started against the "Net takeaway" priority ranking below, backed by a new
+`InlayHintTests.fs` (+ dedicated `Fixtures/genericProject/Project/InlayHintTest.cs` fixture, safe
+to keep extending for further rules without touching other tests):
+
+- ✅ **Rule #1 (same-name suppression gap)** — both sub-fixes landed in `validateParameter`:
+  comparing against the argument expression's significant (trivia-free) identifier text instead
+  of `arg.GetText()`, and matching the last identifier segment of a qualified member-access
+  expression (`this.Foo` vs. parameter `foo`).
+- ✅ **Rule #2 (short / numbered-suffix parameter names)** — `hasUninformativeParameterName`
+  suppresses hints for parameter names of length ≤ 2 or matching `^\w*?\d+$` (`arg0`, `val1`,
+  `path2`, …), with negative-control test coverage for `string.Substring(startIndex, length)` and
+  a `Stream.Write`-shaped `(buffer, offset, count)` method to confirm it doesn't over-suppress.
+  Deliberately narrower than the original per-method-allow-list idea (it does *not* catch
+  `Math.Round`'s `decimals`/`mode`, only `d`) — see the rule's doc comment in `InlayHint.fs` for
+  the rationale.
+- Rules #3–#7 below are not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -591,19 +608,22 @@ argument's own name" rule actually work in the two most common shapes it current
 **Net takeaway across all six samples:** the highest-value, lowest-risk rules to prioritize
 first, ranked roughly by combined volume, confidence, and implementation risk:
 
-1. **Fix the same-name parameter suppression gap** — now root-caused (see above) into two
-   concrete, independent, small fixes: (a) compare significant identifier text instead of raw
-   `GetText()` (likely trivia/whitespace bug), and (b) extend the match to the last segment of
+1. **✅ Implemented.** Fix the same-name parameter suppression gap — now root-caused (see above)
+   into two concrete, independent, small fixes: (a) compare significant identifier text instead of
+   raw `GetText()` (likely trivia/whitespace bug), and (b) extend the match to the last segment of
    qualified member-access arguments (`this.Foo` vs. parameter `foo`). Confirmed across three
    samples against at least three unrelated call sites/helpers; given how idiomatic both call
    shapes are throughout the codebase, this pair of fixes alone would likely eliminate a large
    fraction of real-world noise, before any new heuristic work.
-2. Suppress parameter-name hints for very short (≤ 1–2 character) parameter names and for
-   numbered-suffix parameter names (`arg0`, `val1`, `path2`, i.e. matching `^\w*?\d+$`) —
-   collapses what were three separate special cases (BCL opaque names, format-string args,
-   `Math.Min`/`Max`, `Path.Combine`) into one or two simple, mechanical, method-agnostic rules.
-   Still needs the `string.Substring`/`Stream.Write(buffer, offset, count)`-style counter-example
-   check — i.e. confirm this doesn't fire on short-but-genuinely-disambiguating names.
+2. **✅ Implemented.** Suppress parameter-name hints for very short (≤ 1–2 character) parameter
+   names and for numbered-suffix parameter names (`arg0`, `val1`, `path2`, i.e. matching
+   `^\w*?\d+$`) — collapses what were three separate special cases (BCL opaque names,
+   format-string args, `Math.Min`/`Max`, `Path.Combine`) into one or two simple, mechanical,
+   method-agnostic rules. Confirmed against the `string.Substring`/`Stream.Write(buffer, offset,
+   count)`-style counter-example — it doesn't fire on short-but-genuinely-disambiguating names.
+   Note: intentionally doesn't catch every opaque BCL name this way (e.g. `Math.Round`'s
+   `decimals`/`mode` are kept, only `d` is suppressed) — a per-method allow-list would catch more
+   but was deferred as higher-risk/higher-maintenance.
 3. Suppress parameter-name hints for single lambda/expression-typed arguments passed to methods
    whose own name already conveys the lambda's role and which have no ambiguous overload —
    generalized from "well-known `System.Linq` methods" to also cover other fluent/ORM APIs (e.g.
@@ -638,31 +658,35 @@ built-in suppression heuristics is also to be decided during design.
 
 ## Next Steps
 
-1. Design session to enumerate the exact suppression rules per hint kind (type vs. parameter),
-   informed by the candidates above, the real-world evidence below, and by user/editor feedback
-   on which current hints feel noisy in practice.
-2. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
-   `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize the seven
-   rules ranked in the combined "Net takeaway" above first, in order: the same-name suppression
-   gap fix (two concrete sub-fixes, now root-caused — see below), short/opaque and numbered-suffix
-   parameter names, LINQ-and-friends single-lambda parameter names, composite-format-string
-   positional arguments, generic-type-argument-redundant `var` hints, generalizing same-name
-   suppression to type hints, and (lower priority) `extern`/P-Invoke parameter names.
-3. Land the two same-name suppression gap fixes identified by reading `InlayHint.fs` (see
-   "Root-Cause Analysis" above): (a) compare significant identifier text rather than raw
-   `arg.GetText()` in `validateParameter` (likely a leading-trivia/whitespace bug — verify with a
-   unit test contrasting single-line vs. multi-line indented call sites before committing to this
-   as the fix), and (b) extend the same-name match to also cover the last identifier segment of
-   qualified member-access arguments (`this.Foo` vs. parameter `foo`). Both are small, additive,
-   and testable in isolation from the rest of this plan's heuristic work.
-4. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
+1. ✅ **Done.** Land the two same-name suppression gap fixes identified by reading `InlayHint.fs`
+   (see "Root-Cause Analysis" above): (a) compare significant identifier text rather than raw
+   `arg.GetText()` in `validateParameter`, and (b) extend the same-name match to also cover the
+   last identifier segment of qualified member-access arguments (`this.Foo` vs. parameter `foo`).
+   Landed with dedicated positive/negative test coverage in `InlayHintTests.fs`.
+2. ✅ **Done.** Implement rule #2 (short / numbered-suffix parameter names) as
+   `hasUninformativeParameterName` in `validateParameter`, with test coverage including the
+   `string.Substring`/`Stream.Write(buffer, offset, count)`-style negative controls.
+3. Design session to enumerate the exact suppression rules for the remaining candidates (rules
+   #3–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
+   Gathered So Far"), informed by the real-world evidence above and by user/editor feedback on
+   which current hints still feel noisy in practice.
+4. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
+   `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize, in order:
+   LINQ-and-friends single-lambda parameter names (rule #3), composite-format-string positional
+   arguments (rule #4 — likely already subsumed by rule #2's numbered-suffix pattern; verify and
+   close out if so), generic-type-argument-redundant `var` hints (rule #5), generalizing same-name
+   suppression to type hints (rule #6), and (lower priority) `extern`/P-Invoke parameter names
+   (rule #7).
+5. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
    rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
-   variant).
-5. Decide on and (if wanted) implement the configuration angle above.
+   variant) — extend the existing `InlayHintTests.fs` / `InlayHintTest.cs` fixture rather than
+   creating new ones, so all rules stay exercised against one file.
+6. Decide on and (if wanted) implement the configuration angle above.
 
 ## Files Likely Touched
 
 | File | Likely Change |
 |------|----------------|
-| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add suppression predicates to `toInlayHint`'s match arms, per the design once finalized |
-| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` (if present) or a new test file | Add positive/negative coverage per rule |
+| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1 and #2 already landed) |
+| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1 and #2 already covered) |
+| `tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs` | Extend with new code shapes per remaining rule |

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -24,14 +24,25 @@ to keep extending for further rules without touching other tests):
   `Math.Round`'s `decimals`/`mode`, only `d`) — see the rule's doc comment in `InlayHint.fs` for
   the rationale.
 - ✅ **Rule #3 (single lambda-argument calls)** — `validateParameter` now suppresses the hint for
-  the sole argument of a call when that argument is a lambda expression, regardless of the
-  parameter's own name — covers both LINQ (`Where(predicate)`, `Select(selector)`, …) and other
+  the sole (effective) argument of a call when that argument is a lambda expression, regardless of
+  the parameter's own name — covers both LINQ (`Where(predicate)`, `Select(selector)`, …) and other
   fluent/ORM APIs (NHibernate-style `Fetch(relatedObjectSelector)`/`ThenFetch(...)`). Deliberately
   scoped to single-argument calls (multi-lambda-argument calls like `Combine(first, second)` keep
   both hints) and to lambda expressions specifically (a method-group argument, e.g.
   `Where(IsPositive)`, is out of scope and keeps its hint) — both scoping decisions are covered by
-  dedicated negative-control tests.
-- Rules #4–#7 below are not yet implemented.
+  dedicated negative-control tests. Refined so a trailing `CancellationToken` argument doesn't
+  count towards "effective argument count" (`isCancellationTokenArgument`, matched by name only) —
+  e.g. `WhereAsync(x => x.IsActive, cancellationToken)` is treated the same as
+  `Where(x => x.IsActive)`; a two-lambda call with a trailing token (`CombineAsync(first, second,
+  cancellationToken)`) still correctly keeps both hints.
+- ✅ **Rule #4 (composite-format-string positional arguments)** — investigated and closed out with
+  **no separate implementation**: confirmed via a test mirroring log4net's real
+  `ILog.DebugFormat(string format, object arg0, object arg1, object arg2)` overload shape that
+  `arg0`/`arg1`/`arg2` are already suppressed by rule #2's numbered-suffix pattern
+  (`hasUninformativeParameterName`), while `format:` (not numbered-suffix) correctly stays. The
+  broader originally-proposed heuristic (parse the format string's `{n}` placeholders) turned out
+  to be unnecessary for the evidence gathered.
+- Rules #5–#7 below are not yet implemented.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -639,10 +650,17 @@ first, ranked roughly by combined volume, confidence, and implementation risk:
    the call is a `LambdaExpressionSyntax`) rather than a method allow-list, so it covers any
    fluent/ORM API with this shape for free. Confirmed via tests that it doesn't fire on
    multi-lambda-argument calls (e.g. a hypothetical `Combine(first, second)`) or on method-group
-   arguments (e.g. `Where(IsPositive)`), both of which keep their hints.
-4. Suppress parameter-name hints for arguments following a composite-format string literal
-   (`{0}`/`{1}`/... placeholders) on formatting/logging-style method calls (this may now be fully
-   subsumed by rule #2's numbered-suffix pattern, since `arg0`/`arg1`/`arg2` match it directly).
+   arguments (e.g. `Where(IsPositive)`), both of which keep their hints. Also refined to not count
+   a trailing `CancellationToken` argument towards "sole argument", since it's a conventional,
+   non-essential pass-through parameter on async APIs (`WhereAsync(x => x.IsActive,
+   cancellationToken)` behaves the same as `Where(x => x.IsActive)`).
+4. **✅ Verified subsumed by rule #2, no separate implementation needed.** Suppress
+   parameter-name hints for arguments following a composite-format string literal (`{0}`/`{1}`/...
+   placeholders) on formatting/logging-style method calls. Confirmed via a test mirroring
+   log4net's real `ILog.DebugFormat(string format, object arg0, object arg1, object arg2)`
+   overload shape that `arg0`/`arg1`/`arg2` are already caught by rule #2's numbered-suffix
+   pattern — the broader originally-proposed heuristic (parsing `{n}` placeholders out of the
+   format string) wasn't needed.
 5. Suppress `var` type hints when the initializer is a generic invocation whose explicit
    type-argument list already contains the exact inferred type (e.g. `Enum.Parse<T>()`,
    `JsonSerializer.Deserialize<T>()`) — concrete, low-risk, no allow-list needed.
@@ -679,28 +697,30 @@ built-in suppression heuristics is also to be decided during design.
    `hasUninformativeParameterName` in `validateParameter`, with test coverage including the
    `string.Substring`/`Stream.Write(buffer, offset, count)`-style negative controls.
 3. ✅ **Done.** Implement rule #3 (single lambda-argument calls) as a new `validateParameter`
-   match arm keyed on `argList.Arguments.Count = 1 && (argExpr :? LambdaExpressionSyntax)`, with
-   test coverage for the multi-lambda-argument and method-group-argument negative controls.
-4. Design session to enumerate the exact suppression rules for the remaining candidates (rules
-   #4–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
+   match arm keyed on the argument list's effective (non-`CancellationToken`) argument count being
+   1 and `argExpr :? LambdaExpressionSyntax`, with test coverage for the multi-lambda-argument,
+   method-group-argument, and trailing-`CancellationToken` negative/edge-case controls.
+4. ✅ **Done.** Verify rule #4 (composite-format-string positional arguments) against a
+   `log4net`-shaped `DebugFormat(format, arg0, arg1, arg2)` test — confirmed it's fully subsumed by
+   rule #2's numbered-suffix pattern; closed out with no separate implementation.
+5. Design session to enumerate the exact suppression rules for the remaining candidates (rules
+   #5–#7 in the "Net takeaway" ranking, plus the type-hint-side candidates from "Candidate Ideas
    Gathered So Far"), informed by the real-world evidence above and by user/editor feedback on
    which current hints still feel noisy in practice.
-5. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
+6. Turn the agreed rules into a rule table (condition → suppress/keep) similar in spirit to the
    `validateType` / `validateParameter` predicates already in `InlayHint.fs`. Prioritize, in order:
-   composite-format-string positional arguments (rule #4 — likely already subsumed by rule #2's
-   numbered-suffix pattern; verify and close out if so), generic-type-argument-redundant `var`
-   hints (rule #5), generalizing same-name suppression to type hints (rule #6), and (lower
-   priority) `extern`/P-Invoke parameter names (rule #7).
-6. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
+   generic-type-argument-redundant `var` hints (rule #5), generalizing same-name suppression to
+   type hints (rule #6), and (lower priority) `extern`/P-Invoke parameter names (rule #7).
+7. Implement the agreed predicates in `toInlayHint`, with unit/integration test coverage for each
    rule (positive case: hint suppressed; negative case: hint still shown for the non-redundant
    variant) — extend the existing `InlayHintTests.fs` / `InlayHintTest.cs` fixture rather than
    creating new ones, so all rules stay exercised against one file.
-7. Decide on and (if wanted) implement the configuration angle above.
+8. Decide on and (if wanted) implement the configuration angle above.
 
 ## Files Likely Touched
 
 | File | Likely Change |
 |------|----------------|
-| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1–#3 already landed) |
-| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1–#3 already covered) |
+| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicates to `toInlayHint`'s match arms, per the design once finalized (rules #1–#4 already landed/closed) |
+| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage per remaining rule (rules #1–#4 already covered) |
 | `tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs` | Extend with new code shapes per remaining rule |

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -2,6 +2,7 @@ namespace CSharpLanguageServer.Handlers
 
 open System
 open System.Collections.Immutable
+open System.Text.RegularExpressions
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp
@@ -113,6 +114,12 @@ module InlayHint =
             | _ -> None
         | _ -> None
 
+    // A parameter name matching this pattern (`arg0`, `val1`, `path2`, …) ends in a numeric
+    // suffix and carries essentially no information beyond its argument's position -- see
+    // `hasUninformativeParameterName` below. Module-level (rather than local to `toInlayHint`)
+    // so it's compiled once, not once per syntax node visited per request.
+    let private numberedSuffixParameterName = Regex(@"^\w*?\d+$", RegexOptions.Compiled)
+
     let private toInlayHint
         (semanticModel: SemanticModel)
         (lines: TextLineCollection)
@@ -163,12 +170,26 @@ module InlayHint =
             | :? ParenthesizedExpressionSyntax as paren -> significantArgumentName paren.Expression
             | _ -> expr.ToString()
 
+        // A parameter name that's very short, or ends in a numeric suffix, carries essentially
+        // no information beyond its argument's position (`d`, `s`, `val1`, `arg0`, `path2`, the
+        // real .NET BCL parameter names of e.g. `Guid`'s constructor, `Math.Min`/`Math.Max`,
+        // `Path.Combine`, and composite-format-string overloads like `string.Format`) -- a hint
+        // for it can't help a reader, only add clutter. See plans/inlay-hint-reduction.md for the
+        // real-world evidence behind this heuristic. Deliberately narrow/mechanical: it doesn't
+        // try to catch every opaque BCL name (e.g. `Math.Round`'s `decimals`/`mode`), only the
+        // shapes confirmed safe against genuinely-disambiguating counter-examples like
+        // `string.Substring(startIndex, length)` and `Stream.Write(buffer, offset, count)`.
+        let hasUninformativeParameterName (name: string) =
+            name.Length <= 2 || numberedSuffixParameterName.IsMatch(name)
+
         let validateParameter (arg: SyntaxNode) (argExpr: ExpressionSyntax) (par: IParameterSymbol) =
             match arg.Parent with
             // Don't show hint for indexer
             | :? BracketedArgumentListSyntax -> None
             // Don't show hint if parameter name is empty
             | _ when String.IsNullOrEmpty(par.Name) -> None
+            // Don't show hint if the parameter name itself is too short/generic to be informative
+            | _ when hasUninformativeParameterName par.Name -> None
             // Don't show hint if argument's own name (or, for a qualified member access, its last
             // segment) matches the parameter name
             | _ when String.Equals(significantArgumentName argExpr, par.Name, StringComparison.CurrentCultureIgnoreCase) ->

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -146,11 +146,16 @@ module InlayHint =
     // compared across identifiers using different casing conventions (a local variable:
     // camelCase; a type name: PascalCase). Module-level for the same reason as
     // numberedSuffixParameterName above.
-    let private camelCaseWordBoundary = Regex(@"(?<=[a-z0-9])(?=[A-Z])", RegexOptions.Compiled)
+    let private camelCaseWordBoundary =
+        Regex(@"(?<=[a-z0-9])(?=[A-Z])", RegexOptions.Compiled)
 
     let private lastWord (identifier: string) : string =
         let words = camelCaseWordBoundary.Split(identifier)
-        if words.Length = 0 then identifier else words[words.Length - 1]
+
+        if words.Length = 0 then
+            identifier
+        else
+            words[words.Length - 1]
 
     // True when `identifier` already "echoes" `typeName` -- either a full case-insensitive match
     // (`resourceStatus` vs. `ResourceStatus`, `messageDispatcherAsync` vs.
@@ -265,7 +270,8 @@ module InlayHint =
         // type, so it never matches `:? ITypeSymbol`).
         let rec isTypeSpelledOutInStaticInvocationQualifier (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
             match initializer with
-            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInStaticInvocationQualifier paren.Expression ty
+            | :? ParenthesizedExpressionSyntax as paren ->
+                isTypeSpelledOutInStaticInvocationQualifier paren.Expression ty
             | :? InvocationExpressionSyntax as invocation ->
                 match invocation.Expression with
                 | :? MemberAccessExpressionSyntax as memberAccess ->
@@ -354,8 +360,11 @@ module InlayHint =
             // name alone (e.g. `Dictionary<TKey, TValue>.Add(key, value)`,
             // `List<T>.Insert(int index, T item)` keep all their hints).
             | :? ArgumentListSyntax as argList when
-                ((argExpr :? LambdaExpressionSyntax) || soleArgumentGenericParameterNames.Contains(par.Name))
-                && (argList.Arguments |> Seq.filter (isCancellationTokenArgument >> not) |> Seq.length) = 1
+                ((argExpr :? LambdaExpressionSyntax)
+                 || soleArgumentGenericParameterNames.Contains(par.Name))
+                && (argList.Arguments
+                    |> Seq.filter (isCancellationTokenArgument >> not)
+                    |> Seq.length) = 1
                 ->
                 None
             // Don't show hint if argument's own name (or, for a qualified member access, its last

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -153,6 +153,38 @@ module InlayHint =
               PaddingRight = Some false
               Data = None }
 
+        // Returns true when `initializer` is a generic invocation (optionally on a member access,
+        // e.g. `Enum.Parse<DayOfWeek>(...)`, or unqualified, e.g. a local `CreateLocal<T>()`)
+        // whose explicit type-argument list already contains a type symbol-equal to `ty` -- in
+        // that case a `var` type hint would be purely redundant, since the type is already
+        // spelled out one step to the left in the very same expression (`Enum.Parse<`,
+        // `JsonSerializer.Deserialize<`, `Activator.CreateInstance<`, a local factory method,
+        // ...). Parenthesized expressions are unwrapped. Compares by symbol (not just by name),
+        // so it correctly doesn't fire when the invocation's return type differs from its type
+        // argument (e.g. a hypothetical `Describe<Widget>(...)` returning `string`).
+        let rec isTypeSpelledOutInGenericInvocation (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+            match initializer with
+            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInGenericInvocation paren.Expression ty
+            | :? InvocationExpressionSyntax as invocation ->
+                let genericName =
+                    match invocation.Expression with
+                    | :? GenericNameSyntax as generic -> Some generic
+                    | :? MemberAccessExpressionSyntax as memberAccess ->
+                        match memberAccess.Name with
+                        | :? GenericNameSyntax as generic -> Some generic
+                        | _ -> None
+                    | _ -> None
+
+                genericName
+                |> Option.map (fun generic ->
+                    generic.TypeArgumentList.Arguments
+                    |> Seq.exists (fun typeArgSyntax ->
+                        match semanticModel.GetTypeInfo(typeArgSyntax).Type |> Option.ofObj with
+                        | Some typeArgSymbol -> SymbolEqualityComparer.Default.Equals(typeArgSymbol, ty)
+                        | None -> false))
+                |> Option.defaultValue false
+            | _ -> false
+
         // Returns the significant (trivia-free) name an argument expression is "known by", so it
         // can be compared against a parameter name to detect a redundant hint:
         // - a bare identifier (`resourceName`) contributes its own text
@@ -247,6 +279,14 @@ module InlayHint =
             ->
             semanticModel.GetTypeInfo(var.Type).Type
             |> validateType
+            // Don't show hint if the initializer is a generic invocation whose explicit
+            // type-argument list already spells out this exact type (`Enum.Parse<T>()`,
+            // `JsonSerializer.Deserialize<T>()`, a local generic factory method, ...)
+            |> Option.filter (fun ty ->
+                var.Variables[0].Initializer
+                |> Option.ofObj
+                |> Option.map (fun eq -> not (isTypeSpelledOutInGenericInvocation eq.Value ty))
+                |> Option.defaultValue true)
             |> Option.map (toTypeInlayHint var.Variables[0].Identifier.Span.End)
         // We handle individual variables of ParenthesizedVariableDesignationSyntax separately.
         // For example, in `var (x, y) = (0, "")`, we should `int` for `x` and `string` for `y`.

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -146,14 +146,32 @@ module InlayHint =
               PaddingRight = Some false
               Data = None }
 
-        let validateParameter (arg: SyntaxNode) (par: IParameterSymbol) =
+        // Returns the significant (trivia-free) name an argument expression is "known by", so it
+        // can be compared against a parameter name to detect a redundant hint:
+        // - a bare identifier (`resourceName`) contributes its own text
+        // - a qualified member access (`this.ResourceName`, `foo.Bar.ResourceName`) contributes
+        //   just its last segment, since that's the name a reader actually associates the value
+        //   with
+        // - a parenthesized expression is unwrapped
+        // - anything else falls back to its own (trivia-free) text via ToString(), which is what
+        //   the previous, buggy `arg.GetText()` (a trivia-inclusive, ToFullString()-equivalent
+        //   call) was trying, but failing, to do
+        let rec significantArgumentName (expr: ExpressionSyntax) : string =
+            match expr with
+            | :? IdentifierNameSyntax as ident -> ident.Identifier.ValueText
+            | :? MemberAccessExpressionSyntax as memberAccess -> memberAccess.Name.Identifier.ValueText
+            | :? ParenthesizedExpressionSyntax as paren -> significantArgumentName paren.Expression
+            | _ -> expr.ToString()
+
+        let validateParameter (arg: SyntaxNode) (argExpr: ExpressionSyntax) (par: IParameterSymbol) =
             match arg.Parent with
             // Don't show hint for indexer
             | :? BracketedArgumentListSyntax -> None
             // Don't show hint if parameter name is empty
             | _ when String.IsNullOrEmpty(par.Name) -> None
-            // Don't show hint if argument matches parameter name
-            | _ when String.Equals(arg.GetText().ToString(), par.Name, StringComparison.CurrentCultureIgnoreCase) ->
+            // Don't show hint if argument's own name (or, for a qualified member access, its last
+            // segment) matches the parameter name
+            | _ when String.Equals(significantArgumentName argExpr, par.Name, StringComparison.CurrentCultureIgnoreCase) ->
                 None
             | _ -> Some par
 
@@ -225,12 +243,12 @@ module InlayHint =
         | :? ArgumentSyntax as argument when isNull argument.NameColon ->
             argument
             |> getParameterForArgumentSyntax semanticModel
-            |> Option.bind (validateParameter node)
+            |> Option.bind (validateParameter node argument.Expression)
             |> Option.map (toParameterInlayHint argument.Span.Start)
         | :? AttributeArgumentSyntax as argument when isNull argument.NameEquals && isNull argument.NameColon ->
             argument
             |> getParameterForAttributeArgumentSyntax semanticModel
-            |> Option.bind (validateParameter node)
+            |> Option.bind (validateParameter node argument.Expression)
             |> Option.map (toParameterInlayHint argument.Span.Start)
 
         | _ -> None

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -120,6 +120,13 @@ module InlayHint =
     // so it's compiled once, not once per syntax node visited per request.
     let private numberedSuffixParameterName = Regex(@"^\w*?\d+$", RegexOptions.Compiled)
 
+    // Parameter names that are just a generic placeholder for "the argument", carrying no more
+    // information than the argument's own name/shape already does -- e.g. NHibernate's
+    // `ISession.SaveAsync(object obj, ...)`. Unlike `hasUninformativeParameterName`'s
+    // length/numbered-suffix checks below, these are specific, known-opaque names rather than a
+    // mechanical shape, so they're kept in an explicit, easy-to-extend set instead of a regex.
+    let private genericParameterNames = set [ "obj" ]
+
     // Splits a PascalCase/camelCase identifier into its constituent words (e.g.
     // `settingChangeCondition` -> `setting`, `Change`, `Condition`), so the last word can be
     // compared across identifiers using different casing conventions (a local variable:
@@ -206,6 +213,29 @@ module InlayHint =
                 |> Option.defaultValue false
             | _ -> false
 
+        // Returns true when `initializer` is an explicit object-creation expression (`new
+        // SomeType(...)` / `new SomeType { ... }`) whose spelled-out type is symbol-equal to
+        // `ty` -- in that case a `var` type hint would be purely redundant, since the type is
+        // already spelled out immediately after `new`, one step to the left in the very same
+        // expression (mirrors `isTypeSpelledOutInGenericInvocation` above, but for plain
+        // object-creation rather than an explicit generic type argument). Parenthesized
+        // expressions are unwrapped. Deliberately restricted to explicit
+        // `ObjectCreationExpressionSyntax` -- NOT `ImplicitObjectCreationExpressionSyntax`
+        // (target-typed `new()`), where the type is *not* spelled out and the hint remains the
+        // useful, intended case (handled separately, right after `new`, by the
+        // `ImplicitObjectCreationExpressionSyntax` match arm below). Compares by symbol so it
+        // doesn't fire on a mismatching type (e.g. an upcast via `as`, which isn't unwrapped
+        // here, so its `ObjectCreationExpressionSyntax` operand is never reached in the first
+        // place).
+        let rec isTypeSpelledOutInObjectCreation (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+            match initializer with
+            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInObjectCreation paren.Expression ty
+            | :? ObjectCreationExpressionSyntax as objectCreation ->
+                match semanticModel.GetTypeInfo(objectCreation.Type).Type |> Option.ofObj with
+                | Some createdType -> SymbolEqualityComparer.Default.Equals(createdType, ty)
+                | None -> false
+            | _ -> false
+
         // Returns the significant (trivia-free) name an argument expression is "known by", so it
         // can be compared against a parameter name to detect a redundant hint:
         // - a bare identifier (`resourceName`) contributes its own text
@@ -231,9 +261,13 @@ module InlayHint =
         // real-world evidence behind this heuristic. Deliberately narrow/mechanical: it doesn't
         // try to catch every opaque BCL name (e.g. `Math.Round`'s `decimals`/`mode`), only the
         // shapes confirmed safe against genuinely-disambiguating counter-examples like
-        // `string.Substring(startIndex, length)` and `Stream.Write(buffer, offset, count)`.
+        // `string.Substring(startIndex, length)` and `Stream.Write(buffer, offset, count)`. Also
+        // suppressed for the explicit, known-opaque names in `genericParameterNames` (e.g.
+        // `obj`), which aren't short/numbered enough for the mechanical checks alone to catch.
         let hasUninformativeParameterName (name: string) =
-            name.Length <= 2 || numberedSuffixParameterName.IsMatch(name)
+            name.Length <= 2
+            || numberedSuffixParameterName.IsMatch(name)
+            || genericParameterNames.Contains(name)
 
         // A `CancellationToken` argument is a conventional, non-essential "pass-through"
         // parameter on async APIs, so its presence shouldn't disqualify the single-lambda-argument
@@ -307,11 +341,15 @@ module InlayHint =
             |> validateType
             // Don't show hint if the initializer is a generic invocation whose explicit
             // type-argument list already spells out this exact type (`Enum.Parse<T>()`,
-            // `JsonSerializer.Deserialize<T>()`, a local generic factory method, ...)
+            // `JsonSerializer.Deserialize<T>()`, a local generic factory method, ...), or an
+            // explicit object-creation expression that already spells out this exact type
+            // (`new SomeType(...)` / `new SomeType { ... }`)
             |> Option.filter (fun ty ->
                 var.Variables[0].Initializer
                 |> Option.ofObj
-                |> Option.map (fun eq -> not (isTypeSpelledOutInGenericInvocation eq.Value ty))
+                |> Option.map (fun eq ->
+                    not (isTypeSpelledOutInGenericInvocation eq.Value ty)
+                    && not (isTypeSpelledOutInObjectCreation eq.Value ty))
                 |> Option.defaultValue true)
             // Don't show hint if the variable's own identifier already echoes the type name
             // (`resourceCondition`/`settingChangeCondition` vs. `ResourceCondition`)

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -182,6 +182,21 @@ module InlayHint =
         let hasUninformativeParameterName (name: string) =
             name.Length <= 2 || numberedSuffixParameterName.IsMatch(name)
 
+        // A `CancellationToken` argument is a conventional, non-essential "pass-through"
+        // parameter on async APIs, so its presence shouldn't disqualify the single-lambda-argument
+        // rule below -- e.g. `WhereAsync(x => x.IsActive, cancellationToken)` should be treated
+        // the same as `Where(x => x.IsActive)`. Uses the argument's converted type (rather than
+        // its natural type) so a `default`/`default(CancellationToken)` argument is still
+        // recognized. Matched by name only, not a full compilation-wide symbol lookup, since this
+        // is meant to be a cheap, conventional signal rather than a rigorous type check.
+        let isCancellationTokenArgument (argument: ArgumentSyntax) : bool =
+            let typeInfo = semanticModel.GetTypeInfo(argument.Expression)
+
+            [ typeInfo.ConvertedType; typeInfo.Type ]
+            |> List.tryPick Option.ofObj
+            |> Option.map (fun ty -> ty.Name = "CancellationToken")
+            |> Option.defaultValue false
+
         let validateParameter (arg: SyntaxNode) (argExpr: ExpressionSyntax) (par: IParameterSymbol) =
             match arg.Parent with
             // Don't show hint for indexer
@@ -190,15 +205,19 @@ module InlayHint =
             | _ when String.IsNullOrEmpty(par.Name) -> None
             // Don't show hint if the parameter name itself is too short/generic to be informative
             | _ when hasUninformativeParameterName par.Name -> None
-            // Don't show hint for the sole lambda argument of a call (the enclosing method symbol
-            // is already known to have resolved unambiguously -- see getParameterForArgumentSyntax
-            // above) -- the method's own name already conveys the lambda's role (`Where(predicate)`,
-            // `Select(selector)`, NHibernate-style `Fetch(relatedObjectSelector)`/`ThenFetch(...)`,
-            // ...), so a parameter-name hint here is redundant no matter how generic or specific
-            // that name is. Deliberately scoped to lambda expressions only (not method-group
-            // arguments) and to single-argument calls only -- multiple lambda parameters in one
-            // call aren't each automatically self-describing from the method name alone.
-            | :? ArgumentListSyntax as argList when argList.Arguments.Count = 1 && (argExpr :? LambdaExpressionSyntax) ->
+            // Don't show hint for the sole (non-CancellationToken) argument of a call (the
+            // enclosing method symbol is already known to have resolved unambiguously -- see
+            // getParameterForArgumentSyntax above) when that argument is a lambda -- the method's
+            // own name already conveys the lambda's role (`Where(predicate)`, `Select(selector)`,
+            // NHibernate-style `Fetch(relatedObjectSelector)`/`ThenFetch(...)`, ...), so a
+            // parameter-name hint here is redundant no matter how generic or specific that name
+            // is. Deliberately scoped to lambda expressions only (not method-group arguments) and
+            // to single-(effective-)argument calls only -- multiple lambda parameters in one call
+            // aren't each automatically self-describing from the method name alone.
+            | :? ArgumentListSyntax as argList when
+                (argExpr :? LambdaExpressionSyntax)
+                && (argList.Arguments |> Seq.filter (isCancellationTokenArgument >> not) |> Seq.length) = 1
+                ->
                 None
             // Don't show hint if argument's own name (or, for a qualified member access, its last
             // segment) matches the parameter name

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -190,6 +190,16 @@ module InlayHint =
             | _ when String.IsNullOrEmpty(par.Name) -> None
             // Don't show hint if the parameter name itself is too short/generic to be informative
             | _ when hasUninformativeParameterName par.Name -> None
+            // Don't show hint for the sole lambda argument of a call (the enclosing method symbol
+            // is already known to have resolved unambiguously -- see getParameterForArgumentSyntax
+            // above) -- the method's own name already conveys the lambda's role (`Where(predicate)`,
+            // `Select(selector)`, NHibernate-style `Fetch(relatedObjectSelector)`/`ThenFetch(...)`,
+            // ...), so a parameter-name hint here is redundant no matter how generic or specific
+            // that name is. Deliberately scoped to lambda expressions only (not method-group
+            // arguments) and to single-argument calls only -- multiple lambda parameters in one
+            // call aren't each automatically self-describing from the method name alone.
+            | :? ArgumentListSyntax as argList when argList.Arguments.Count = 1 && (argExpr :? LambdaExpressionSyntax) ->
+                None
             // Don't show hint if argument's own name (or, for a qualified member access, its last
             // segment) matches the parameter name
             | _ when String.Equals(significantArgumentName argExpr, par.Name, StringComparison.CurrentCultureIgnoreCase) ->

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -125,7 +125,21 @@ module InlayHint =
     // `ISession.SaveAsync(object obj, ...)`. Unlike `hasUninformativeParameterName`'s
     // length/numbered-suffix checks below, these are specific, known-opaque names rather than a
     // mechanical shape, so they're kept in an explicit, easy-to-extend set instead of a regex.
+    // Applied unconditionally, regardless of how many arguments the call has -- safe only for
+    // names that stay uninformative no matter the position (unlike `soleArgumentGenericParameterNames`
+    // below).
     let private genericParameterNames = set [ "obj" ]
+
+    // Parameter names that are only uninformative when they're the call's sole (effective)
+    // argument -- e.g. `value` in `validStatusList.Contains(this.Order.Status)`, or `item` in
+    // `orderProduct.SupplierOrderRequestProducts.Add(requestProduct)`, where `Contains`/`Add`
+    // already convey the single argument's role just as clearly as a lambda does for `Where`.
+    // Deliberately kept out of the always-on `genericParameterNames` set above: both legitimately
+    // help disambiguate a *multi*-argument call (e.g. `Dictionary<TKey, TValue>.Add(key, value)`,
+    // `List<T>.Insert(int index, T item)`), so they're only safe to suppress when there's nothing
+    // to disambiguate -- see their scoped use in `validateParameter` below, alongside the
+    // sole-lambda-argument rule this set extends.
+    let private soleArgumentGenericParameterNames = set [ "value"; "item" ]
 
     // Splits a PascalCase/camelCase identifier into its constituent words (e.g.
     // `settingChangeCondition` -> `setting`, `Change`, `Condition`), so the last word can be
@@ -236,6 +250,31 @@ module InlayHint =
                 | None -> false
             | _ -> false
 
+        // Returns true when `initializer` is an invocation of a static member accessed through
+        // its declaring type's own name (`string.Format(...)`, `Guid.NewGuid()`, `int.Parse(...)`,
+        // ...) where that qualifying type is itself symbol-equal to `ty` -- in that case a `var`
+        // type hint would be purely redundant, since the type is already spelled out immediately
+        // to the left of `.` in the very same expression (the qualifier-based sibling of
+        // `isTypeSpelledOutInGenericInvocation`'s type-argument-based check above). Parenthesized
+        // expressions are unwrapped. `GetSymbolInfo` (not `GetTypeInfo`) is used on the qualifier
+        // because a type used as a static-member-access receiver doesn't have a "value type" of
+        // its own -- its symbol *is* the type. Compares by symbol, so it correctly doesn't fire
+        // when the qualifier is an unrelated type whose name doesn't match the return type (e.g.
+        // `Convert.ToInt32(...)`, qualifier `Convert` vs. return type `int`) or when the qualifier
+        // is an instance (a local/field/property access resolves to that member's symbol, not a
+        // type, so it never matches `:? ITypeSymbol`).
+        let rec isTypeSpelledOutInStaticInvocationQualifier (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+            match initializer with
+            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInStaticInvocationQualifier paren.Expression ty
+            | :? InvocationExpressionSyntax as invocation ->
+                match invocation.Expression with
+                | :? MemberAccessExpressionSyntax as memberAccess ->
+                    match semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol |> Option.ofObj with
+                    | Some(:? ITypeSymbol as qualifierType) -> SymbolEqualityComparer.Default.Equals(qualifierType, ty)
+                    | _ -> false
+                | _ -> false
+            | _ -> false
+
         // Returns the significant (trivia-free) name an argument expression is "known by", so it
         // can be compared against a parameter name to detect a redundant hint:
         // - a bare identifier (`resourceName`) contributes its own text
@@ -299,15 +338,23 @@ module InlayHint =
             | _ when identifierEchoesTypeName par.Name par.Type.Name -> None
             // Don't show hint for the sole (non-CancellationToken) argument of a call (the
             // enclosing method symbol is already known to have resolved unambiguously -- see
-            // getParameterForArgumentSyntax above) when that argument is a lambda -- the method's
-            // own name already conveys the lambda's role (`Where(predicate)`, `Select(selector)`,
-            // NHibernate-style `Fetch(relatedObjectSelector)`/`ThenFetch(...)`, ...), so a
-            // parameter-name hint here is redundant no matter how generic or specific that name
-            // is. Deliberately scoped to lambda expressions only (not method-group arguments) and
-            // to single-(effective-)argument calls only -- multiple lambda parameters in one call
-            // aren't each automatically self-describing from the method name alone.
+            // getParameterForArgumentSyntax above) when either:
+            // - that argument is a lambda -- the method's own name already conveys the lambda's
+            //   role (`Where(predicate)`, `Select(selector)`, NHibernate-style
+            //   `Fetch(relatedObjectSelector)`/`ThenFetch(...)`, ...), so a parameter-name hint
+            //   here is redundant no matter how generic or specific that name is. Deliberately
+            //   scoped to lambda expressions only (not method-group arguments); or
+            // - the parameter's own name is in `soleArgumentGenericParameterNames` (e.g. `value`
+            //   in `Contains(value)`, or `item` in `someCollection.Add(item)`) -- with only one
+            //   argument there's no position to disambiguate, so the name adds nothing beyond
+            //   what the method name (`Contains`, `Add`, ...) already conveys, regardless of the
+            //   argument expression's shape.
+            // Both cases are scoped to single-(effective-)argument calls only -- multiple
+            // arguments in one call aren't each automatically self-describing from the method
+            // name alone (e.g. `Dictionary<TKey, TValue>.Add(key, value)`,
+            // `List<T>.Insert(int index, T item)` keep all their hints).
             | :? ArgumentListSyntax as argList when
-                (argExpr :? LambdaExpressionSyntax)
+                ((argExpr :? LambdaExpressionSyntax) || soleArgumentGenericParameterNames.Contains(par.Name))
                 && (argList.Arguments |> Seq.filter (isCancellationTokenArgument >> not) |> Seq.length) = 1
                 ->
                 None
@@ -341,15 +388,17 @@ module InlayHint =
             |> validateType
             // Don't show hint if the initializer is a generic invocation whose explicit
             // type-argument list already spells out this exact type (`Enum.Parse<T>()`,
-            // `JsonSerializer.Deserialize<T>()`, a local generic factory method, ...), or an
-            // explicit object-creation expression that already spells out this exact type
-            // (`new SomeType(...)` / `new SomeType { ... }`)
+            // `JsonSerializer.Deserialize<T>()`, a local generic factory method, ...), an explicit
+            // object-creation expression that already spells out this exact type (`new
+            // SomeType(...)` / `new SomeType { ... }`), or a static invocation qualified by this
+            // exact type's own name (`string.Format(...)`, `Guid.NewGuid()`, ...)
             |> Option.filter (fun ty ->
                 var.Variables[0].Initializer
                 |> Option.ofObj
                 |> Option.map (fun eq ->
                     not (isTypeSpelledOutInGenericInvocation eq.Value ty)
-                    && not (isTypeSpelledOutInObjectCreation eq.Value ty))
+                    && not (isTypeSpelledOutInObjectCreation eq.Value ty)
+                    && not (isTypeSpelledOutInStaticInvocationQualifier eq.Value ty))
                 |> Option.defaultValue true)
             // Don't show hint if the variable's own identifier already echoes the type name
             // (`resourceCondition`/`settingChangeCondition` vs. `ResourceCondition`)

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -120,6 +120,27 @@ module InlayHint =
     // so it's compiled once, not once per syntax node visited per request.
     let private numberedSuffixParameterName = Regex(@"^\w*?\d+$", RegexOptions.Compiled)
 
+    // Splits a PascalCase/camelCase identifier into its constituent words (e.g.
+    // `settingChangeCondition` -> `setting`, `Change`, `Condition`), so the last word can be
+    // compared across identifiers using different casing conventions (a local variable:
+    // camelCase; a type name: PascalCase). Module-level for the same reason as
+    // numberedSuffixParameterName above.
+    let private camelCaseWordBoundary = Regex(@"(?<=[a-z0-9])(?=[A-Z])", RegexOptions.Compiled)
+
+    let private lastWord (identifier: string) : string =
+        let words = camelCaseWordBoundary.Split(identifier)
+        if words.Length = 0 then identifier else words[words.Length - 1]
+
+    // True when `identifier` already "echoes" `typeName` -- either a full case-insensitive match
+    // (`resourceStatus` vs. `ResourceStatus`, `messageDispatcherAsync` vs.
+    // `MessageDispatcherAsync`), or their last words match (`settingChangeCondition` vs.
+    // `ResourceCondition`, both ending in "Condition"). In either case, a hint would just restate
+    // what the identifier's own name already conveys. See plans/inlay-hint-reduction.md for the
+    // real-world evidence behind this heuristic.
+    let private identifierEchoesTypeName (identifier: string) (typeName: string) : bool =
+        String.Equals(identifier, typeName, StringComparison.CurrentCultureIgnoreCase)
+        || String.Equals(lastWord identifier, lastWord typeName, StringComparison.CurrentCultureIgnoreCase)
+
     let private toInlayHint
         (semanticModel: SemanticModel)
         (lines: TextLineCollection)
@@ -237,6 +258,11 @@ module InlayHint =
             | _ when String.IsNullOrEmpty(par.Name) -> None
             // Don't show hint if the parameter name itself is too short/generic to be informative
             | _ when hasUninformativeParameterName par.Name -> None
+            // Don't show hint if the parameter's own name is just a (decapitalized) echo of its
+            // own declared type (e.g. a `MessageDispatcherAsync messageDispatcherAsync`
+            // parameter) -- the parameter-hint analogue of the identifier-echoes-type-name rule
+            // applied to type hints below
+            | _ when identifierEchoesTypeName par.Name par.Type.Name -> None
             // Don't show hint for the sole (non-CancellationToken) argument of a call (the
             // enclosing method symbol is already known to have resolved unambiguously -- see
             // getParameterForArgumentSyntax above) when that argument is a lambda -- the method's
@@ -287,6 +313,9 @@ module InlayHint =
                 |> Option.ofObj
                 |> Option.map (fun eq -> not (isTypeSpelledOutInGenericInvocation eq.Value ty))
                 |> Option.defaultValue true)
+            // Don't show hint if the variable's own identifier already echoes the type name
+            // (`resourceCondition`/`settingChangeCondition` vs. `ResourceCondition`)
+            |> Option.filter (fun ty -> not (identifierEchoesTypeName var.Variables[0].Identifier.ValueText ty.Name))
             |> Option.map (toTypeInlayHint var.Variables[0].Identifier.Span.End)
         // We handle individual variables of ParenthesizedVariableDesignationSyntax separately.
         // For example, in `var (x, y) = (0, "")`, we should `int` for `x` and `string` for `y`.
@@ -297,6 +326,11 @@ module InlayHint =
             ->
             semanticModel.GetTypeInfo(dec.Type).Type
             |> validateType
+            |> Option.filter (fun ty ->
+                match dec.Designation with
+                | :? SingleVariableDesignationSyntax as designation ->
+                    not (identifierEchoesTypeName designation.Identifier.ValueText ty.Name)
+                | _ -> true)
             |> Option.map (toTypeInlayHint dec.Designation.Span.End)
         | :? SingleVariableDesignationSyntax as var when
             not (var.Parent :? DeclarationPatternSyntax)
@@ -309,10 +343,12 @@ module InlayHint =
                 | _ -> None
             |> Option.map (fun local -> local.Type)
             |> Option.bind validateType
+            |> Option.filter (fun ty -> not (identifierEchoesTypeName var.Identifier.ValueText ty.Name))
             |> Option.map (toTypeInlayHint var.Identifier.Span.End)
         | :? ForEachStatementSyntax as forEach when forEach.Type.IsVar ->
             semanticModel.GetForEachStatementInfo(forEach).ElementType
             |> validateType
+            |> Option.filter (fun ty -> not (identifierEchoesTypeName forEach.Identifier.ValueText ty.Name))
             |> Option.map (toTypeInlayHint forEach.Identifier.Span.End)
         | :? ParameterSyntax as parameterNode when isNull parameterNode.Type ->
             let parameter = semanticModel.GetDeclaredSymbol(parameterNode)

--- a/tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
+++ b/tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="WorkspaceTests.fs" />
     <Compile Include="CallHierarchyTests.fs" />
     <Compile Include="FoldingRangeTests.fs" />
+    <Compile Include="InlayHintTests.fs" />
     <Compile Include="SourceGeneratorTests.fs" />
     <Compile Include="JsonRpcTests.fs" />
   </ItemGroup>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -160,4 +160,55 @@ namespace Project.InlayHintTest
             new FluentQuery().Where(IsPositive);
         }
     }
+
+    // Mirrors the real log4net `ILog.DebugFormat` overload shapes cited in
+    // plans/inlay-hint-reduction.md's rule #4 evidence: explicit `arg0`/`arg1`/`arg2` parameters
+    // rather than a single `params object[] args`.
+    public class Logger
+    {
+        public void DebugFormat(string format, object arg0, object arg1, object arg2)
+        {
+        }
+    }
+
+    public class LoggerSubject
+    {
+        public void CompositeFormatStringPositionalArgumentsAreSuppressed()
+        {
+            new Logger().DebugFormat("{0}: {1} did {2}", 1, 2, 3);
+        }
+    }
+
+    // A trailing CancellationToken argument is a conventional, non-essential "pass-through"
+    // parameter on async APIs, so it shouldn't disqualify the single-lambda-argument rule (#3).
+    public class FluentQueryAsync
+    {
+        public FluentQueryAsync WhereAsync(
+            System.Func<int, bool> predicate,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            return this;
+        }
+
+        public FluentQueryAsync CombineAsync(
+            System.Func<int, int> first,
+            System.Func<int, int> second,
+            System.Threading.CancellationToken cancellationToken)
+        {
+            return this;
+        }
+    }
+
+    public class FluentQueryAsyncSubject
+    {
+        public void SingleLambdaArgumentWithTrailingCancellationTokenIsSuppressed()
+        {
+            new FluentQueryAsync().WhereAsync(x => x > 0, default);
+        }
+
+        public void MultiLambdaArgumentWithTrailingCancellationTokenKeepsHints()
+        {
+            new FluentQueryAsync().CombineAsync(x => x, x => x, default);
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -112,4 +112,52 @@ namespace Project.InlayHintTest
             helper.WriteBuffer(data, 0, data.Length);
         }
     }
+
+    public class FluentQuery
+    {
+        public FluentQuery Where(System.Func<int, bool> predicate)
+        {
+            return this;
+        }
+
+        public FluentQuery Fetch(System.Func<int, int> relatedObjectSelector)
+        {
+            return this;
+        }
+
+        public FluentQuery ThenFetch(System.Func<int, int> relatedObjectSelector)
+        {
+            return this;
+        }
+
+        public FluentQuery Combine(System.Func<int, int> first, System.Func<int, int> second)
+        {
+            return this;
+        }
+    }
+
+    public class FluentQuerySubject
+    {
+        private static bool IsPositive(int x) => x > 0;
+
+        public void SingleLambdaArgumentToWhereIsSuppressed()
+        {
+            new FluentQuery().Where(x => x > 0);
+        }
+
+        public void SingleLambdaArgumentToFluentOrmStyleMethodIsSuppressed()
+        {
+            new FluentQuery().Fetch(x => x).ThenFetch(x => x);
+        }
+
+        public void MultiLambdaArgumentCallKeepsHints()
+        {
+            new FluentQuery().Combine(x => x, x => x);
+        }
+
+        public void SingleMethodGroupArgumentKeepsHint()
+        {
+            new FluentQuery().Where(IsPositive);
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -65,4 +65,51 @@ namespace Project.InlayHintTest
                 "other");
         }
     }
+
+    public class ShortAndNumberedParameterHelper
+    {
+        public void SetX(int x)
+        {
+        }
+
+        public void WriteBuffer(byte[] buffer, int offset, int count)
+        {
+        }
+    }
+
+    public class ShortAndNumberedParameterSubject
+    {
+        private readonly ShortAndNumberedParameterHelper helper = new ShortAndNumberedParameterHelper();
+
+        public void ShortParameterNameIsSuppressed()
+        {
+            helper.SetX(5);
+        }
+
+        public void NumberedSuffixParameterNameIsSuppressed()
+        {
+            string.Format("{0} {1}", 1, 2);
+        }
+
+        public void WellKnownBclNumberedSuffixParameterNamesAreSuppressed()
+        {
+            System.Math.Min(1, 2);
+        }
+
+        public void OpaqueBclShortParameterNamesAreSuppressed()
+        {
+            System.Math.Round(1.23m, 2, System.MidpointRounding.AwayFromZero);
+        }
+
+        public void DisambiguatingParameterNamesKeepHint()
+        {
+            "hello".Substring(1, 2);
+        }
+
+        public void BufferOffsetCountParameterNamesKeepHint()
+        {
+            var data = new byte[] { 1, 2, 3 };
+            helper.WriteBuffer(data, 0, data.Length);
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -322,4 +322,48 @@ namespace Project.InlayHintTest
             DispatchWithGenericName(null);
         }
     }
+
+    public class GenericParameterNameHelper
+    {
+        public void Save(object obj)
+        {
+        }
+
+        public void Log(string msg)
+        {
+        }
+    }
+
+    public class GenericParameterNameSubject
+    {
+        private readonly GenericParameterNameHelper helper = new GenericParameterNameHelper();
+
+        public void GenericObjParameterNameIsSuppressed()
+        {
+            helper.Save(5);
+        }
+
+        public void NonGenericSameLengthParameterNameKeepsHint()
+        {
+            helper.Log("hi");
+        }
+    }
+
+    public class WidgetWithProperty
+    {
+        public int Value { get; set; }
+    }
+
+    public class ExplicitObjectCreationTypeHintSubject
+    {
+        public void ExplicitObjectCreationTypeHintIsSuppressed()
+        {
+            var widget = new Widget();
+        }
+
+        public void ExplicitObjectCreationWithInitializerTypeHintIsSuppressed()
+        {
+            var widget = new WidgetWithProperty { Value = 1 };
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -256,4 +256,70 @@ namespace Project.InlayHintTest
             var day = System.Enum.Parse<System.DayOfWeek>("Monday");
         }
     }
+
+    public delegate void MessageDispatcherAsync();
+
+    public class ResourceCondition
+    {
+    }
+
+    public class IdentifierEchoesTypeSubject
+    {
+        private static ResourceCondition GetCondition()
+        {
+            return new ResourceCondition();
+        }
+
+        private static System.Collections.Generic.List<Widget> GetWidgets()
+        {
+            return new System.Collections.Generic.List<Widget>();
+        }
+
+        private static void Dispatch(MessageDispatcherAsync messageDispatcherAsync)
+        {
+        }
+
+        private static void DispatchWithGenericName(MessageDispatcherAsync handler)
+        {
+        }
+
+        public void FullNameMatchTypeHintIsSuppressed()
+        {
+            var resourceCondition = GetCondition();
+        }
+
+        public void LastWordMatchTypeHintIsSuppressed()
+        {
+            var settingChangeCondition = GetCondition();
+        }
+
+        public void NonMatchingIdentifierKeepsTypeHint()
+        {
+            var outcome = GetCondition();
+        }
+
+        public void ForeachVariableEchoingElementTypeIsSuppressed()
+        {
+            foreach (var widget in GetWidgets())
+            {
+            }
+        }
+
+        public void ForeachVariableNotEchoingElementTypeKeepsHint()
+        {
+            foreach (var item in GetWidgets())
+            {
+            }
+        }
+
+        public void ParameterNameEchoingOwnTypeIsSuppressed()
+        {
+            Dispatch(null);
+        }
+
+        public void ParameterNameNotEchoingOwnTypeKeepsHint()
+        {
+            DispatchWithGenericName(null);
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -366,4 +366,70 @@ namespace Project.InlayHintTest
             var widget = new WidgetWithProperty { Value = 1 };
         }
     }
+
+    public class ValueParameterHelper
+    {
+        public bool Contains(int value)
+        {
+            return value > 0;
+        }
+
+        public void Add(int key, int value)
+        {
+        }
+    }
+
+    public class ValueParameterSubject
+    {
+        private readonly ValueParameterHelper helper = new ValueParameterHelper();
+
+        public void SoleValueParameterNameIsSuppressed()
+        {
+            helper.Contains(5);
+        }
+
+        public void MultiArgumentValueParameterNameKeepsHint()
+        {
+            helper.Add(1, 2);
+        }
+    }
+
+    public class StaticQualifierTypeHintSubject
+    {
+        public void StaticQualifierMatchingReturnTypeIsSuppressed()
+        {
+            var reason = string.Format("{0}", 1);
+        }
+
+        public void StaticQualifierNotMatchingReturnTypeKeepsHint()
+        {
+            var converted = System.Convert.ToInt32("5");
+        }
+    }
+
+    public class ItemParameterHelper
+    {
+        public void Add(int item)
+        {
+        }
+
+        public void Insert(int index, int item)
+        {
+        }
+    }
+
+    public class ItemParameterSubject
+    {
+        private readonly ItemParameterHelper helper = new ItemParameterHelper();
+
+        public void SoleItemParameterNameIsSuppressed()
+        {
+            helper.Add(5);
+        }
+
+        public void MultiArgumentItemParameterNameKeepsHint()
+        {
+            helper.Insert(0, 5);
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -211,4 +211,49 @@ namespace Project.InlayHintTest
             new FluentQueryAsync().CombineAsync(x => x, x => x, default);
         }
     }
+
+    public class Widget
+    {
+    }
+
+    public static class GenericFactory
+    {
+        public static T Create<T>() where T : new()
+        {
+            return new T();
+        }
+
+        public static string Describe<T>(T value)
+        {
+            return value?.ToString() ?? "";
+        }
+    }
+
+    public class GenericFactorySubject
+    {
+        private T CreateLocal<T>() where T : new()
+        {
+            return new T();
+        }
+
+        public void QualifiedGenericInvocationSpellingOutTypeIsSuppressed()
+        {
+            var widget = GenericFactory.Create<Widget>();
+        }
+
+        public void QualifiedGenericInvocationWithDifferentReturnTypeKeepsHint()
+        {
+            var description = GenericFactory.Describe<Widget>(new Widget());
+        }
+
+        public void UnqualifiedGenericInvocationSpellingOutTypeIsSuppressed()
+        {
+            var widget = CreateLocal<Widget>();
+        }
+
+        public void RealBclEnumParseGenericInvocationIsSuppressed()
+        {
+            var day = System.Enum.Parse<System.DayOfWeek>("Monday");
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -1,0 +1,68 @@
+namespace Project.InlayHintTest
+{
+    public class InlayHintHelper
+    {
+        public void WithResource(string resourceName, string other)
+        {
+        }
+
+        public int Add(int first, int second)
+        {
+            return first + second;
+        }
+    }
+
+    public class InlayHintSubject
+    {
+        private readonly InlayHintHelper helper = new InlayHintHelper();
+
+        public string ResourceName { get; set; } = "";
+        public string OtherValue { get; set; } = "";
+
+        private int GetCount() => 42;
+
+        public void TypeHintOnVarDeclaration()
+        {
+            var count = GetCount();
+        }
+
+        public void ParameterHintOnRegularCall()
+        {
+            helper.Add(1, 2);
+        }
+
+        public void SameNameSingleLineArgumentIsSuppressed()
+        {
+            string resourceName = "abc";
+            helper.WithResource(resourceName, "other");
+        }
+
+        public void SameNameMultiLineArgumentIsSuppressed()
+        {
+            string resourceName = "abc";
+            helper.WithResource(
+                resourceName,
+                "other");
+        }
+
+        public void QualifiedMemberAccessSameNameIsSuppressed()
+        {
+            helper.WithResource(
+                this.ResourceName,
+                "other");
+        }
+
+        public void DifferentNameArgumentKeepsHint()
+        {
+            string somethingElse = "abc";
+            helper.WithResource(somethingElse, "other");
+        }
+
+        public void DifferentQualifiedMemberAccessKeepsHint()
+        {
+            helper.WithResource(
+                this.OtherValue,
+                "other");
+        }
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -738,3 +738,124 @@ let ``textDocument/inlayHint suppresses a var type hint when an explicit object-
              right after `new`, even with an object initializer), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a hint for the sole "value" parameter of a call`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 387 (0-indexed): `helper.Contains(5);` -- sole parameter is `value`
+    let onLine = hints |> hintsOnLine 387u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "value:",
+        sprintf
+            "Expected no \"value:\" hint on line 387 (sole argument, method name conveys role), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a "value" parameter hint when the call has more than one argument`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 392 (0-indexed): `helper.Add(1, 2);` -- parameters are `key`, `value`
+    let onLine = hints |> hintsOnLine 392u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "key:",
+        sprintf "Expected a \"key:\" hint on line 392 (call has more than one argument), got: %A" onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "value:",
+        sprintf
+            "Expected a \"value:\" hint on line 392 (call has more than one argument, so \"value\"\
+             still helps disambiguate from \"key\"), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when a static invocation's qualifier matches the return type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 400 (0-indexed): `var reason = string.Format("{0}", 1);`
+    let onLine = hints |> hintsOnLine 400u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": string",
+        sprintf
+            "Expected no \": string\" hint on line 400 (type is already spelled out as the\
+             invocation's qualifier), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a var type hint when a static invocation's qualifier doesn't match the return type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 405 (0-indexed): `var converted = System.Convert.ToInt32("5");`
+    // -- qualifier is `Convert`, return type is `int`
+    let onLine = hints |> hintsOnLine 405u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel ": int",
+        sprintf
+            "Expected a \": int\" hint on line 405 (invocation's qualifier doesn't match the\
+             return type), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a hint for the sole "item" parameter of a call`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 426 (0-indexed): `helper.Add(5);` -- sole parameter is `item`
+    let onLine = hints |> hintsOnLine 426u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "item:",
+        sprintf
+            "Expected no \"item:\" hint on line 426 (sole argument, method name conveys role), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps an "item" parameter hint when the call has more than one argument`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 431 (0-indexed): `helper.Insert(0, 5);` -- parameters are `index`, `item`
+    let onLine = hints |> hintsOnLine 431u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "index:",
+        sprintf "Expected an \"index:\" hint on line 431 (call has more than one argument), got: %A" onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "item:",
+        sprintf
+            "Expected an \"item:\" hint on line 431 (call has more than one argument, so \"item\"\
+             still helps disambiguate from \"index\"), got: %A"
+            onLine
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -290,3 +290,84 @@ let ``textDocument/inlayHint keeps hints for buffer/offset/count-style parameter
     Assert.IsTrue(onLine |> hasHintWithLabel "offset:", sprintf "Expected an \"offset:\" hint on line 111, got: %A" onLine)
 
     Assert.IsTrue(onLine |> hasHintWithLabel "count:", sprintf "Expected a \"count:\" hint on line 111, got: %A" onLine)
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a hint for the sole lambda argument of a fluent LINQ-style call``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 144 (0-indexed): `new FluentQuery().Where(x => x > 0);` -- parameter is `predicate`
+    let onLine = hints |> hintsOnLine 144u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "predicate:",
+        sprintf
+            "Expected no \"predicate:\" hint on line 144 (sole lambda argument, method name conveys role), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses hints for the sole lambda argument of chained fluent ORM-style calls``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 149 (0-indexed): `new FluentQuery().Fetch(x => x).ThenFetch(x => x);`
+    // -- both parameters are `relatedObjectSelector`
+    let onLine = hints |> hintsOnLine 149u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "relatedObjectSelector:",
+        sprintf
+            "Expected no \"relatedObjectSelector:\" hint on line 149 (sole lambda argument of each\
+             call, method name conveys role), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps hints when a call takes more than one lambda argument`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 154 (0-indexed): `new FluentQuery().Combine(x => x, x => x);`
+    // -- parameters are `first`, `second`
+    let onLine = hints |> hintsOnLine 154u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "first:",
+        sprintf "Expected a \"first:\" hint on line 154 (call has more than one lambda argument), got: %A" onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "second:",
+        sprintf "Expected a \"second:\" hint on line 154 (call has more than one lambda argument), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a hint when the sole argument is a method group rather than a lambda``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 159 (0-indexed): `new FluentQuery().Where(IsPositive);` -- parameter is `predicate`
+    let onLine = hints |> hintsOnLine 159u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "predicate:",
+        sprintf
+            "Expected a \"predicate:\" hint on line 159 (sole argument is a method group, not a lambda\
+             expression -- out of scope for this rule), got: %A"
+            onLine
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -530,3 +530,139 @@ let ``textDocument/inlayHint suppresses a var type hint for the real Enum.Parse<
              Enum.Parse's explicit type argument), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when the identifier fully matches the inferred type name``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 287 (0-indexed): `var resourceCondition = GetCondition();`
+    let onLine = hints |> hintsOnLine 287u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": ResourceCondition",
+        sprintf
+            "Expected no \": ResourceCondition\" hint on line 287 (identifier is a full\
+             case-insensitive match of the inferred type name), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when the identifier's last word matches the inferred type's last word``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 292 (0-indexed): `var settingChangeCondition = GetCondition();`
+    let onLine = hints |> hintsOnLine 292u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": ResourceCondition",
+        sprintf
+            "Expected no \": ResourceCondition\" hint on line 292 (identifier's last word\
+             \"Condition\" matches the inferred type's last word), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a var type hint when the identifier doesn't echo the inferred type name``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 297 (0-indexed): `var outcome = GetCondition();`
+    let onLine = hints |> hintsOnLine 297u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel ": ResourceCondition",
+        sprintf
+            "Expected a \": ResourceCondition\" hint on line 297 (identifier doesn't echo the\
+             inferred type name), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a foreach variable's type hint when the identifier echoes the element type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 302 (0-indexed): `foreach (var widget in GetWidgets())`
+    let onLine = hints |> hintsOnLine 302u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": Widget",
+        sprintf
+            "Expected no \": Widget\" hint on line 302 (identifier is a full case-insensitive\
+             match of the element type name), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a foreach variable's type hint when the identifier doesn't echo the element type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 309 (0-indexed): `foreach (var item in GetWidgets())`
+    let onLine = hints |> hintsOnLine 309u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel ": Widget",
+        sprintf "Expected a \": Widget\" hint on line 309 (identifier doesn't echo the element type), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a parameter-name hint when the parameter name echoes its own declared type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 316 (0-indexed): `Dispatch(null);` -- parameter is `MessageDispatcherAsync messageDispatcherAsync`
+    let onLine = hints |> hintsOnLine 316u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "messageDispatcherAsync:",
+        sprintf
+            "Expected no \"messageDispatcherAsync:\" hint on line 316 (parameter name is a\
+             decapitalized echo of its own declared type), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a parameter-name hint when the parameter name doesn't echo its own declared type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 321 (0-indexed): `DispatchWithGenericName(null);` -- parameter is `MessageDispatcherAsync handler`
+    let onLine = hints |> hintsOnLine 321u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "handler:",
+        sprintf
+            "Expected a \"handler:\" hint on line 321 (parameter name doesn't echo its own declared type), got: %A"
+            onLine
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -1,0 +1,165 @@
+module CSharpLanguageServer.Tests.InlayHintTests
+
+open NUnit.Framework
+open Ionide.LanguageServerProtocol.Types
+
+open CSharpLanguageServer.Tests.Tooling
+
+/// Requests inlay hints for the whole document. `Position.toLinePosition` clamps an
+/// out-of-range line to the document's last line, so a large End.Line is a convenient way to
+/// cover "the whole file" without knowing its exact length.
+let private wholeDocumentInlayHintParams (doc: LspDocumentHandle) : InlayHintParams =
+    { TextDocument = { Uri = doc.Uri }
+      Range =
+        { Start = { Line = 0u; Character = 0u }
+          End = { Line = 1000000u; Character = 0u } }
+      WorkDoneToken = None }
+
+let private getHints (client: LspTestClient) (doc: LspDocumentHandle) : InlayHint array =
+    let result: InlayHint array option =
+        client.Request("textDocument/inlayHint", wholeDocumentInlayHintParams doc)
+
+    result |> Option.defaultValue Array.empty
+
+let private labelText (hint: InlayHint) : string =
+    match hint.Label with
+    | U2.C1 s -> s
+    | U2.C2 _ -> ""
+
+let private hintsOnLine (line: uint32) (hints: InlayHint array) : InlayHint array =
+    hints |> Array.filter (fun h -> h.Position.Line = line)
+
+let private hasHintWithLabel (label: string) (hints: InlayHint array) : bool =
+    hints |> Array.exists (fun h -> labelText h = label)
+
+[<Test>]
+let ``textDocument/inlayHint shows a type hint for a var declaration initialized from a method call`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 25 (0-indexed): `var count = GetCount();`
+    let onLine = hints |> hintsOnLine 25u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel ": int",
+        sprintf "Expected a \": int\" type hint on line 25, got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint shows parameter hints for a regular call with differently-named arguments`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 30 (0-indexed): `helper.Add(1, 2);`
+    let onLine = hints |> hintsOnLine 30u
+
+    Assert.IsTrue(onLine |> hasHintWithLabel "first:", sprintf "Expected a \"first:\" hint on line 30, got: %A" onLine)
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "second:",
+        sprintf "Expected a \"second:\" hint on line 30, got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a same-name single-line argument (regression guard)`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 36 (0-indexed): `helper.WithResource(resourceName, "other");`
+    let onLine = hints |> hintsOnLine 36u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "resourceName:",
+        sprintf "Expected no \"resourceName:\" hint on line 36 (argument matches parameter name), got: %A" onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "other:",
+        sprintf "Expected an \"other:\" hint on line 36 (argument doesn't match parameter name), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a same-name argument on its own indented line`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // lines 42-44 (0-indexed):
+    //     helper.WithResource(
+    //         resourceName,
+    //         "other");
+    let onLine = hints |> hintsOnLine 43u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "resourceName:",
+        sprintf
+            "Expected no \"resourceName:\" hint on line 43 (argument matches parameter name, only\
+             differs by leading whitespace/newline trivia), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a qualified member-access argument matching the parameter name`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // lines 49-51 (0-indexed):
+    //     helper.WithResource(
+    //         this.ResourceName,
+    //         "other");
+    let onLine = hints |> hintsOnLine 50u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "resourceName:",
+        sprintf
+            "Expected no \"resourceName:\" hint on line 50 (this.ResourceName's last segment matches\
+             the parameter name), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a hint when the argument name doesn't match the parameter name`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 57 (0-indexed): `helper.WithResource(somethingElse, "other");`
+    let onLine = hints |> hintsOnLine 57u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "resourceName:",
+        sprintf "Expected a \"resourceName:\" hint on line 57 (argument doesn't match parameter name), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a hint when a qualified member-access argument's last segment doesn't match the parameter name``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // lines 62-64 (0-indexed):
+    //     helper.WithResource(
+    //         this.OtherValue,
+    //         "other");
+    let onLine = hints |> hintsOnLine 63u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "resourceName:",
+        sprintf
+            "Expected a \"resourceName:\" hint on line 63 (this.OtherValue's last segment doesn't\
+             match the parameter name), got: %A"
+            onLine
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -225,9 +225,7 @@ let ``textDocument/inlayHint suppresses Math.Min's numbered-suffix parameter nam
     )
 
 [<Test>]
-let ``textDocument/inlayHint suppresses Math.Round's short parameter name but keeps its longer, still-opaque ones``
-    ()
-    =
+let ``textDocument/inlayHint suppresses Math.Round's short parameter name but keeps its longer, still-opaque ones`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -256,9 +254,7 @@ let ``textDocument/inlayHint suppresses Math.Round's short parameter name but ke
     )
 
 [<Test>]
-let ``textDocument/inlayHint keeps hints for string.Substring's genuinely-disambiguating parameter names``
-    ()
-    =
+let ``textDocument/inlayHint keeps hints for string.Substring's genuinely-disambiguating parameter names`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -272,7 +268,10 @@ let ``textDocument/inlayHint keeps hints for string.Substring's genuinely-disamb
         sprintf "Expected a \"startIndex:\" hint on line 105, got: %A" onLine
     )
 
-    Assert.IsTrue(onLine |> hasHintWithLabel "length:", sprintf "Expected a \"length:\" hint on line 105, got: %A" onLine)
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "length:",
+        sprintf "Expected a \"length:\" hint on line 105, got: %A" onLine
+    )
 
 [<Test>]
 let ``textDocument/inlayHint keeps hints for buffer/offset/count-style parameter names`` () =
@@ -285,16 +284,20 @@ let ``textDocument/inlayHint keeps hints for buffer/offset/count-style parameter
     // -- parameters are `buffer`, `offset`, `count`
     let onLine = hints |> hintsOnLine 111u
 
-    Assert.IsTrue(onLine |> hasHintWithLabel "buffer:", sprintf "Expected a \"buffer:\" hint on line 111, got: %A" onLine)
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "buffer:",
+        sprintf "Expected a \"buffer:\" hint on line 111, got: %A" onLine
+    )
 
-    Assert.IsTrue(onLine |> hasHintWithLabel "offset:", sprintf "Expected an \"offset:\" hint on line 111, got: %A" onLine)
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "offset:",
+        sprintf "Expected an \"offset:\" hint on line 111, got: %A" onLine
+    )
 
     Assert.IsTrue(onLine |> hasHintWithLabel "count:", sprintf "Expected a \"count:\" hint on line 111, got: %A" onLine)
 
 [<Test>]
-let ``textDocument/inlayHint suppresses a hint for the sole lambda argument of a fluent LINQ-style call``
-    ()
-    =
+let ``textDocument/inlayHint suppresses a hint for the sole lambda argument of a fluent LINQ-style call`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -311,9 +314,7 @@ let ``textDocument/inlayHint suppresses a hint for the sole lambda argument of a
     )
 
 [<Test>]
-let ``textDocument/inlayHint suppresses hints for the sole lambda argument of chained fluent ORM-style calls``
-    ()
-    =
+let ``textDocument/inlayHint suppresses hints for the sole lambda argument of chained fluent ORM-style calls`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -353,9 +354,7 @@ let ``textDocument/inlayHint keeps hints when a call takes more than one lambda 
     )
 
 [<Test>]
-let ``textDocument/inlayHint keeps a hint when the sole argument is a method group rather than a lambda``
-    ()
-    =
+let ``textDocument/inlayHint keeps a hint when the sole argument is a method group rather than a lambda`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -387,7 +386,10 @@ let ``textDocument/inlayHint suppresses composite-format-string positional argum
     // already match rule #2's numbered-suffix pattern (`hasUninformativeParameterName`).
     let onLine = hints |> hintsOnLine 177u
 
-    Assert.IsTrue(onLine |> hasHintWithLabel "format:", sprintf "Expected a \"format:\" hint on line 177, got: %A" onLine)
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "format:",
+        sprintf "Expected a \"format:\" hint on line 177, got: %A" onLine
+    )
 
     Assert.IsFalse(
         onLine |> hasHintWithLabel "arg0:",
@@ -426,9 +428,7 @@ let ``textDocument/inlayHint suppresses a hint for a single lambda argument foll
     )
 
 [<Test>]
-let ``textDocument/inlayHint keeps hints for multiple lambda arguments even with a trailing CancellationToken``
-    ()
-    =
+let ``textDocument/inlayHint keeps hints for multiple lambda arguments even with a trailing CancellationToken`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -440,16 +440,12 @@ let ``textDocument/inlayHint keeps hints for multiple lambda arguments even with
 
     Assert.IsTrue(
         onLine |> hasHintWithLabel "first:",
-        sprintf
-            "Expected a \"first:\" hint on line 210 (more than one non-CancellationToken argument), got: %A"
-            onLine
+        sprintf "Expected a \"first:\" hint on line 210 (more than one non-CancellationToken argument), got: %A" onLine
     )
 
     Assert.IsTrue(
         onLine |> hasHintWithLabel "second:",
-        sprintf
-            "Expected a \"second:\" hint on line 210 (more than one non-CancellationToken argument), got: %A"
-            onLine
+        sprintf "Expected a \"second:\" hint on line 210 (more than one non-CancellationToken argument), got: %A" onLine
     )
 
 [<Test>]
@@ -532,9 +528,7 @@ let ``textDocument/inlayHint suppresses a var type hint for the real Enum.Parse<
     )
 
 [<Test>]
-let ``textDocument/inlayHint suppresses a var type hint when the identifier fully matches the inferred type name``
-    ()
-    =
+let ``textDocument/inlayHint suppresses a var type hint when the identifier fully matches the inferred type name`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -572,9 +566,7 @@ let ``textDocument/inlayHint suppresses a var type hint when the identifier's la
     )
 
 [<Test>]
-let ``textDocument/inlayHint keeps a var type hint when the identifier doesn't echo the inferred type name``
-    ()
-    =
+let ``textDocument/inlayHint keeps a var type hint when the identifier doesn't echo the inferred type name`` () =
     use client = activateFixture "genericProject"
     use doc = client.Open "Project/InlayHintTest.cs"
 
@@ -751,9 +743,7 @@ let ``textDocument/inlayHint suppresses a hint for the sole "value" parameter of
 
     Assert.IsFalse(
         onLine |> hasHintWithLabel "value:",
-        sprintf
-            "Expected no \"value:\" hint on line 387 (sole argument, method name conveys role), got: %A"
-            onLine
+        sprintf "Expected no \"value:\" hint on line 387 (sole argument, method name conveys role), got: %A" onLine
     )
 
 [<Test>]
@@ -832,9 +822,7 @@ let ``textDocument/inlayHint suppresses a hint for the sole "item" parameter of 
 
     Assert.IsFalse(
         onLine |> hasHintWithLabel "item:",
-        sprintf
-            "Expected no \"item:\" hint on line 426 (sole argument, method name conveys role), got: %A"
-            onLine
+        sprintf "Expected no \"item:\" hint on line 426 (sole argument, method name conveys role), got: %A" onLine
     )
 
 [<Test>]

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -371,3 +371,83 @@ let ``textDocument/inlayHint keeps a hint when the sole argument is a method gro
              expression -- out of scope for this rule), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses composite-format-string positional argument hints (rule #4, subsumed by rule #2)``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 177 (0-indexed): `new Logger().DebugFormat("{0}: {1} did {2}", 1, 2, 3);`
+    // -- parameters are `format`, `arg0`, `arg1`, `arg2` (mirrors log4net's real ILog.DebugFormat
+    // overload shapes). No dedicated implementation was needed for this: `arg0`/`arg1`/`arg2`
+    // already match rule #2's numbered-suffix pattern (`hasUninformativeParameterName`).
+    let onLine = hints |> hintsOnLine 177u
+
+    Assert.IsTrue(onLine |> hasHintWithLabel "format:", sprintf "Expected a \"format:\" hint on line 177, got: %A" onLine)
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "arg0:",
+        sprintf "Expected no \"arg0:\" hint on line 177 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "arg1:",
+        sprintf "Expected no \"arg1:\" hint on line 177 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "arg2:",
+        sprintf "Expected no \"arg2:\" hint on line 177 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a hint for a single lambda argument followed by a trailing CancellationToken``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 205 (0-indexed): `new FluentQueryAsync().WhereAsync(x => x > 0, default);`
+    // -- parameters are `predicate`, `cancellationToken`
+    let onLine = hints |> hintsOnLine 205u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "predicate:",
+        sprintf
+            "Expected no \"predicate:\" hint on line 205 (sole non-CancellationToken argument is a\
+             lambda, method name conveys role), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps hints for multiple lambda arguments even with a trailing CancellationToken``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 210 (0-indexed): `new FluentQueryAsync().CombineAsync(x => x, x => x, default);`
+    // -- parameters are `first`, `second`, `cancellationToken`
+    let onLine = hints |> hintsOnLine 210u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "first:",
+        sprintf
+            "Expected a \"first:\" hint on line 210 (more than one non-CancellationToken argument), got: %A"
+            onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "second:",
+        sprintf
+            "Expected a \"second:\" hint on line 210 (more than one non-CancellationToken argument), got: %A"
+            onLine
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -666,3 +666,75 @@ let ``textDocument/inlayHint keeps a parameter-name hint when the parameter name
             "Expected a \"handler:\" hint on line 321 (parameter name doesn't echo its own declared type), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a hint for the generic "obj" parameter name`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 342 (0-indexed): `helper.Save(5);` -- parameter is `object obj`
+    let onLine = hints |> hintsOnLine 342u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "obj:",
+        sprintf "Expected no \"obj:\" hint on line 342 (\"obj\" is a generic placeholder name), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a hint for a same-length parameter name that isn't "obj"`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 347 (0-indexed): `helper.Log("hi");` -- parameter is `string msg`
+    let onLine = hints |> hintsOnLine 347u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "msg:",
+        sprintf
+            "Expected a \"msg:\" hint on line 347 (\"msg\" isn't the generic \"obj\" exception, only\
+             coincidentally the same length), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when an explicit object-creation expression spells out the type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 360 (0-indexed): `var widget = new Widget();`
+    let onLine = hints |> hintsOnLine 360u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": Widget",
+        sprintf
+            "Expected no \": Widget\" hint on line 360 (type is already spelled out right after `new`), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when an explicit object-creation expression with an initializer spells out the type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 365 (0-indexed): `var widget = new WidgetWithProperty { Value = 1 };`
+    let onLine = hints |> hintsOnLine 365u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": WidgetWithProperty",
+        sprintf
+            "Expected no \": WidgetWithProperty\" hint on line 365 (type is already spelled out\
+             right after `new`, even with an object initializer), got: %A"
+            onLine
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -163,3 +163,130 @@ let ``textDocument/inlayHint keeps a hint when a qualified member-access argumen
              match the parameter name), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a hint for a very short (1-character) parameter name`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 85 (0-indexed): `helper.SetX(5);` -- parameter is `x`
+    let onLine = hints |> hintsOnLine 85u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "x:",
+        sprintf "Expected no \"x:\" hint on line 85 (parameter name is too short to be informative), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses numbered-suffix parameter names but keeps a normal one`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 90 (0-indexed): `string.Format("{0} {1}", 1, 2);` -- parameters are `format`, `arg0`, `arg1`
+    let onLine = hints |> hintsOnLine 90u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "arg0:",
+        sprintf "Expected no \"arg0:\" hint on line 90 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "arg1:",
+        sprintf "Expected no \"arg1:\" hint on line 90 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "format:",
+        sprintf "Expected a \"format:\" hint on line 90 (not a numbered-suffix parameter name), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses Math.Min's numbered-suffix parameter names`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 95 (0-indexed): `System.Math.Min(1, 2);` -- parameters are `val1`, `val2`
+    let onLine = hints |> hintsOnLine 95u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "val1:",
+        sprintf "Expected no \"val1:\" hint on line 95 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "val2:",
+        sprintf "Expected no \"val2:\" hint on line 95 (numbered-suffix parameter name), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses Math.Round's short parameter name but keeps its longer, still-opaque ones``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 100 (0-indexed): `System.Math.Round(1.23m, 2, System.MidpointRounding.AwayFromZero);`
+    // -- parameters are `d`, `decimals`, `mode`
+    let onLine = hints |> hintsOnLine 100u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel "d:",
+        sprintf "Expected no \"d:\" hint on line 100 (parameter name is too short to be informative), got: %A" onLine
+    )
+
+    // `decimals`/`mode` aren't short or numbered-suffix, so the narrow mechanical rule
+    // intentionally doesn't suppress them (unlike `d`), even though they're arguably still
+    // low-information BCL names -- see plans/inlay-hint-reduction.md for the rationale.
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "decimals:",
+        sprintf "Expected a \"decimals:\" hint on line 100 (not short or numbered-suffix), got: %A" onLine
+    )
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "mode:",
+        sprintf "Expected a \"mode:\" hint on line 100 (not short or numbered-suffix), got: %A" onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps hints for string.Substring's genuinely-disambiguating parameter names``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 105 (0-indexed): `"hello".Substring(1, 2);` -- parameters are `startIndex`, `length`
+    let onLine = hints |> hintsOnLine 105u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel "startIndex:",
+        sprintf "Expected a \"startIndex:\" hint on line 105, got: %A" onLine
+    )
+
+    Assert.IsTrue(onLine |> hasHintWithLabel "length:", sprintf "Expected a \"length:\" hint on line 105, got: %A" onLine)
+
+[<Test>]
+let ``textDocument/inlayHint keeps hints for buffer/offset/count-style parameter names`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 111 (0-indexed): `helper.WriteBuffer(data, 0, data.Length);`
+    // -- parameters are `buffer`, `offset`, `count`
+    let onLine = hints |> hintsOnLine 111u
+
+    Assert.IsTrue(onLine |> hasHintWithLabel "buffer:", sprintf "Expected a \"buffer:\" hint on line 111, got: %A" onLine)
+
+    Assert.IsTrue(onLine |> hasHintWithLabel "offset:", sprintf "Expected an \"offset:\" hint on line 111, got: %A" onLine)
+
+    Assert.IsTrue(onLine |> hasHintWithLabel "count:", sprintf "Expected a \"count:\" hint on line 111, got: %A" onLine)

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -451,3 +451,82 @@ let ``textDocument/inlayHint keeps hints for multiple lambda arguments even with
             "Expected a \"second:\" hint on line 210 (more than one non-CancellationToken argument), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when a qualified generic invocation's type argument matches``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 240 (0-indexed): `var widget = GenericFactory.Create<Widget>();`
+    let onLine = hints |> hintsOnLine 240u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": Widget",
+        sprintf
+            "Expected no \": Widget\" hint on line 240 (type is already spelled out in the\
+             invocation's explicit type argument), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a var type hint when a generic invocation's type argument doesn't match the inferred type``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 245 (0-indexed): `var description = GenericFactory.Describe<Widget>(new Widget());`
+    // -- `Describe<Widget>` returns `string`, not `Widget`
+    let onLine = hints |> hintsOnLine 245u
+
+    Assert.IsTrue(
+        onLine |> hasHintWithLabel ": string",
+        sprintf
+            "Expected a \": string\" hint on line 245 (inferred type doesn't match the invocation's\
+             type argument), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when an unqualified generic invocation's type argument matches``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 250 (0-indexed): `var widget = CreateLocal<Widget>();`
+    let onLine = hints |> hintsOnLine 250u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": Widget",
+        sprintf
+            "Expected no \": Widget\" hint on line 250 (type is already spelled out in the\
+             unqualified invocation's explicit type argument), got: %A"
+            onLine
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint for the real Enum.Parse<T> BCL example`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 255 (0-indexed): `var day = System.Enum.Parse<System.DayOfWeek>("Monday");`
+    let onLine = hints |> hintsOnLine 255u
+
+    Assert.IsFalse(
+        onLine |> hasHintWithLabel ": DayOfWeek",
+        sprintf
+            "Expected no \": DayOfWeek\" hint on line 255 (type is already spelled out in\
+             Enum.Parse's explicit type argument), got: %A"
+            onLine
+    )


### PR DESCRIPTION
Suppresses `textDocument/inlayHint` noise in `Handlers/InlayHint.fs`:

- Fixes the same-name suppression gap (multi-line/indented arguments, and qualified `this.Foo`-style arguments)
- Suppresses hints for uninformative parameter names: length ≤ 2, numbered-suffix (`arg0`, `val1`, …), and a small allow-list (`obj`, sole `value`)
- Suppresses parameter hints for the sole lambda argument of a call (LINQ, fluent/ORM APIs)
- Suppresses redundant `var` type hints when the type is already spelled out (generic type argument, object creation, or static invocation qualifier)
- Suppresses type/parameter hints when the identifier already echoes the type name

Adds `InlayHintTests.fs` with positive and negative-control coverage for each rule. See `plans/inlay-hint-reduction.md` for the full research/design writeup.