### PR TITLE
Remove implicit lambda-parameter type hints

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [windows-latest, ubuntu-24.04]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-* Reduce superfluous `textDocument/inlayHint` noise: fix the same-name argument suppression gap (multi-line/indented and qualified `this.Foo`-style arguments), suppress uninformative parameter names (short, numbered-suffix, `obj`/sole `value`) and sole-lambda-argument calls, and suppress redundant `var` type hints when the type is already spelled out or echoed by the identifier
-  - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/375
+* Reduce superfluous `textDocument/inlayHint` noise: suppress redundant parameter-name and `var` type hints, and remove implicit lambda-parameter type hints entirely
+  - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/375 and https://github.com/razzmatazz/csharp-language-server/pull/376
 * Upgrade Roslyn (`Microsoft.CodeAnalysis.*`) packages to 5.6.0 and MSBuild (`Microsoft.Build`/`Microsoft.Build.Framework`) packages to 18.7.1
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/374
 * Fix Razor support breaking on .NET SDK 10.0.300+: the Razor source generator's `HintName` format

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1,11 +1,12 @@
 # Reducing Superfluous Inlay Hints
 
 **Status:** Full design/rule-table pass for the remaining candidates still not started, but
-informed by seven real-world samples (an MVC controller, two large business-logic "ops" classes, a
+informed by eight real-world samples (an MVC controller, two large business-logic "ops" classes, a
 companion pair of MVC controller files, a small API controller, a diverse batch spanning a
-controller/file-I/O utility/Win32 interop/message handler, and a large private ERP/CRM codebase
-session) — see the "Real-World Evidence" sections below for concrete label-frequency data pulled
-from live `csharp-ls-rpc.log` sessions, plus a source-level root-cause diagnosis of the same-name
+controller/file-I/O utility/Win32 interop/message handler, a large private ERP/CRM codebase
+session, and a targeted follow-up spot-check of two more files from that same session) — see the
+"Real-World Evidence" sections below for concrete label-frequency data pulled from live
+`csharp-ls-rpc.log` sessions, plus a source-level root-cause diagnosis of the same-name
 suppression gap (from reading `InlayHint.fs` directly).
 
 Implementation has started against the "Net takeaway" priority ranking below, backed by a new
@@ -140,6 +141,33 @@ to keep extending for further rules without touching other tests):
   `Combine(first, second)`), or (b) a narrow allow-list of known `System.Linq.Enumerable`
   method names with all-lambda arguments (lower risk, needs maintenance). Deferred pending a
   decision in a future design session.
+- ✅ **New rule (`as`-cast-redundant `var` type hints)** — prompted by an eighth real
+  `csharp-ls-rpc.log` spot-check (see "Eighth Sample" below), `var other = obj as DBBankAccount;`
+  (illustrative name) in an entity class's `Equals(object obj)` override, which showed a
+  `": DBBankAccount"` hint even though the type is spelled out immediately after `as`, on the same
+  line. The `as`-cast sibling of rule #5/the object-creation and static-qualifier rules above:
+  added `isTypeSpelledOutInAsExpression`, which suppresses the `var` type hint when the initializer
+  is a `BinaryExpressionSyntax` of `AsExpression` kind whose right-hand (target) type is
+  symbol-equal to the inferred variable type. Uses `GetSymbolInfo` (not `GetTypeInfo`) on the
+  right-hand side, for the same reason as the static-qualifier rule: it's a type reference, not a
+  value-producing expression. Covered by a positive test (`obj as Widget`).
+- ✅ **New rule (literal/interpolated-string-redundant `var` type hints)** — prompted by two more
+  examples from the same eighth spot-check: a bare string literal assigned to a local later reused
+  as an NHibernate `UniqueKey` name (illustrative rename: `var uniqueAccountKey =
+  "account_number_unique";`), and `var logMessage = $"{level}: {message}";` (illustrative names)
+  in a trace/log-handler class — both showed a redundant `": string"`/`": string?"` hint despite
+  the type being directly implied by the initializer's own syntax. This is the
+  `LiteralExpressionSyntax` candidate from Roslyn's own `CSharpInlineTypeHintsService` prior art
+  (see the "Candidate Ideas" section below), extended to also cover
+  `InterpolatedStringExpressionSyntax` (whose natural type, absent any target typing -- which a
+  `var` declaration never provides -- is always `string`). Added
+  `isTypeSpelledOutInLiteralOrInterpolatedString`, covering numeric, string, character, and
+  boolean literals plus interpolated strings. Deliberately excludes the `null`/`default` literals
+  (neither reveals a specific type on its own) and doesn't unwrap non-literal wrapping expressions
+  like a unary-negated numeric (`var x = -1` is a `PrefixUnaryExpressionSyntax`, not itself a
+  `LiteralExpressionSyntax`, and is deliberately left alone -- covered by a dedicated
+  negative-control test). Covered by positive tests for each literal kind plus the interpolated
+  string, and the unary-negation negative control.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -893,6 +921,69 @@ remain worth pursuing but are lower-volume, more subjective, and/or a different 
 (length vs. redundancy) than the nine above. Equally important: this sample reinforced that
 **negative test cases matter as much as positive ones** — `Stream.Write(buffer, offset, count)`
 and `oldValue`/`newValue`-style handlers are concrete, real examples where hints must be kept.
+
+## Real-World Evidence: Eighth Sample (Follow-Up Spot-Check, Two More Files)
+
+A targeted follow-up spot-check of two more files from the same private ERP/CRM-adjacent codebase
+session as the seventh sample (an entity class with a hand-written `Equals`/`GetHashCode`
+override plus a FluentNHibernate mapping class, and a small trace/log-event handler class),
+captured via `~/csharp-ls-rpc.log`. Unlike the seventh sample's broad label-frequency tally, this
+was a narrow, line-by-line check of a single `textDocument/inlayHint` response per file — but it
+surfaced two new type-hint redundancy shapes not covered by any of the six `isTypeSpelledOutIn*`
+rules implemented so far, both now fixed:
+
+1. **An `as`-cast's target type is already spelled out on the same line, but nothing suppressed
+   it.** The entity class's `Equals` override followed the common
+   `object.Equals(object)`-overriding pattern:
+
+   ```csharp
+   public override bool Equals(object obj)
+   {
+       var other = obj as DBBankAccount;  // illustrative name
+       return other != null && this.Id == other.Id;
+   }
+   ```
+
+   → hinted `": DBBankAccount"` (technically `": DBBankAccount?"`, since `as` always produces a
+   nullable result) on `other`, even though `DBBankAccount` is spelled out four characters to the
+   left, right after `as`, in the very same statement. None of the five existing
+   `isTypeSpelledOutIn*` checks (generic-invocation, object-creation, static-invocation-qualifier)
+   matched this shape — it's syntactically distinct from all three (a `BinaryExpressionSyntax`, not
+   an `InvocationExpressionSyntax`/`ObjectCreationExpressionSyntax`). This is exactly the
+   `BinaryExpressionSyntax` with `AsExpression` kind candidate from Roslyn's own
+   `CSharpInlineTypeHintsService` prior art, cited in this doc's "Candidate Ideas" section since
+   the very first draft but never implemented until now.
+2. **A bare literal or interpolated string's type is directly implied by its own syntax, but
+   nothing suppressed that either.** Two distinct concrete examples, from the two different files:
+
+   ```csharp
+   // In the FluentNHibernate mapping class's constructor:
+   var uniqueAccountKey = "account_number_unique";  // illustrative rename
+   ```
+
+   → hinted `": string"` on a plain string literal — about as unambiguous as a type hint gets.
+   And, from the trace/log-handler class (also seen re-hinting the same shape repeatedly across
+   its handler methods):
+
+   ```csharp
+   var logMessage = $"{level}: {message}";  // illustrative names
+   ```
+
+   → hinted `": string?"` on an interpolated string. An interpolated string's natural type,
+   absent any target typing (which a `var` declaration never provides), is always `string` — every
+   bit as self-evident as a bare literal. Neither shape is covered by Roslyn's own
+   `LiteralExpressionSyntax` candidate as originally scoped (which only covers literals, not
+   interpolated strings), so the implementation (`isTypeSpelledOutInLiteralOrInterpolatedString`)
+   extends it to cover both, while deliberately *not* unwrapping a unary-negated numeric
+   (`var x = -1`, a `PrefixUnaryExpressionSyntax`) or the `null`/`default` literals (neither of
+   which implies a specific type on its own) -- both confirmed via dedicated negative-control
+   tests.
+
+Both fixes are small, additive `validateType` filters mirroring the existing
+`isTypeSpelledOutInGenericInvocation`/`isTypeSpelledOutInObjectCreation`/
+`isTypeSpelledOutInStaticInvocationQualifier` pattern -- no new heuristic *category*, just two more
+initializer shapes recognized within the already-established "type is spelled out in the
+initializer" rule family.
 
 ## Configuration Angle
 

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -188,6 +188,12 @@ to keep extending for further rules without touching other tests):
   maintenance. Covered by a positive test mirroring the real shape and a negative control where the
   explicit generic invocation happens in a separate statement (so it's outside this initializer's
   own invocation chain), which correctly keeps the hint.
+- ✅ **Type hint label truncation** (see "Type Hint Label Truncation" below) — a presentational,
+  not suppression, follow-up prompted by direct user feedback: type-hint labels longer than 40
+  characters (anonymous types, tuples, and any unusually long named type alike) are now
+  middle-truncated with a `"..."` ellipsis via `truncateMiddle`, with the full, untruncated name
+  moved to the hint's `Tooltip` field rather than lost. Closes out the "anonymous-type hints can be
+  very long" nuance raised in the third sample below.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -532,6 +538,8 @@ even higher volume, and surfaces two genuinely new points:
    framework this doc has used so far. But the sheer rendered length is its own distinct
    complaint — worth tracking separately as a possible follow-up (e.g. truncating/eliding
    anonymous-type hints beyond N members) rather than folding it into the suppress/keep binary.
+   **✅ Done** (see the "Type Hint Label Truncation" section below): implemented as a general,
+   length-based middle-truncation, not scoped specifically to anonymous types.
 
 ## Real-World Evidence: Fourth Sample (MVC Controller, Two Companion Files)
 
@@ -1110,6 +1118,34 @@ actual cause. This also lines up with `SymbolEqualityComparer.Default` (already 
 `isTypeSpelledOutIn*` check) being documented to ignore top-level nullable-annotation differences
 when comparing symbols, so a `DBSalesOrder` vs. `DBSalesOrder?` mismatch was never actually a risk
 here in the first place.
+
+## Type Hint Label Truncation
+
+Orthogonal to every suppression rule above (which decide *whether* to show a hint at all), this is
+a UX-only follow-up on *how* a shown type hint is rendered, closing out the "anonymous-type hints
+can be very long" nuance raised in the third sample above -- prompted directly by user feedback
+rather than a fresh `csharp-ls-rpc.log` sample. Compound types -- anonymous types (`<anonymous
+type: int Year, int Month, ..., int InvoiceCount>`) and tuples (`(string Code, string Value, string
+Name, string UIValue)`) -- have no fixed upper bound on their rendered length: they grow with every
+additional member/element, and unlike a suppressible redundant hint, the information in an
+anonymous/tuple type's shape genuinely isn't available anywhere else (there's no name to look up).
+So rather than a suppress/keep decision, the fix is purely presentational.
+
+Implemented as `truncateMiddle` in `InlayHint.fs`: any rendered type-hint label longer than
+`maxTypeHintLabelLength` (40 characters, not counting the leading `": "`) is middle-truncated with
+a `"..."` ellipsis, keeping the head and tail (roughly evenly split) and eliding only the interior.
+The middle (rather than just the tail) is elided so both ends stay visible -- the head usually
+carries the outermost/generic type name or the first tuple element, while the tail often carries
+the last, sometimes most-distinguishing member. Deliberately a general, length-based rule (not
+scoped specifically to `AnonymousTypeSymbol`/tuple types) -- simpler to implement and reason about,
+and a small number of unusually long named types benefit from the same treatment for free. When
+truncation happens, the full, untruncated type name is moved to the hint's `Tooltip` field (a
+first-class LSP inlay-hint field, previously always `None` for type hints), so the elided
+information is still just a hover away rather than lost; a hint that isn't truncated gets no
+tooltip at all, matching prior behavior exactly. Covered by a positive test (a five-property
+anonymous type, confirming the label is short, contains an ellipsis, and carries a longer,
+ellipsis-free tooltip) and a negative control (an ordinary `string`-typed hint, confirming it's
+left untouched with no tooltip added).
 
 ## Configuration Angle
 

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1071,6 +1071,46 @@ evidence's *exact* syntactic shape (including `await`), not just its type-level 
 original fixture's `.ToList()` (no `await`) exercised the new helper's core logic but missed this
 specific, common wrapper.
 
+**Second follow-up: the `await`-unwrapping gap wasn't specific to the new chain-walking rule --
+it affected rule #5's *original* shape too.** A third real file from the same session (illustrative
+description below) surfaced the same missing hint via the simplest possible version of rule #5,
+with no chain-walking involved at all:
+
+```csharp
+var order = await db.GetAsync<DBSalesOrder>(orderConfirmed.OrderId);  // illustrative entity name
+```
+
+→ still hinted `": DBSalesOrder?"`, even though `DBSalesOrder` is spelled out immediately as
+`GetAsync`'s own explicit type argument, one step to the left, in the very same expression. This
+is rule #5's exact original, simplest case (`isTypeSpelledOutInGenericInvocation`) -- not a
+multi-call chain -- just wrapped in `await`, which `isTypeSpelledOutInGenericInvocation` never
+unwrapped either (it only ever handled `ParenthesizedExpressionSyntax`). Confirmed test-first with
+a minimal reproduction *deliberately using a variable name unrelated to the type* (`result`, not
+`order`/`widget`) so the regression test couldn't accidentally pass for the unrelated
+identifier-echoes-type-name reason (rule #6) instead of the intended one -- confirmed red before
+the fix, green after.
+
+Since `await` can only ever wrap the *entire* initializer expression once, at the very outside (a
+chain can't be partially awaited mid-expression), the fix consolidates unwrapping into one shared,
+top-level helper, `unwrapAwaitAndParens`, applied once to the initializer before it's handed to
+*any* of the `isTypeSpelledOutIn*` checks -- rather than teaching each individual check (or, as in
+the first follow-up above, just the newest one) to unwrap `await` itself. This is a strictly better
+fix than a locally-scoped one: it also transparently covers `isTypeSpelledOutInObjectCreation`,
+`isTypeSpelledOutInStaticInvocationQualifier`, and `isTypeSpelledOutInAsExpression`, none of which
+had a reported real-world failure yet, but all of which had the identical latent gap (e.g. `var x =
+await FetchAsync() as SomeType;` would have been equally unaffected by
+`isTypeSpelledOutInAsExpression` before this fix).
+
+One question raised while investigating: whether the real miss was actually about nullable
+annotations (`DBSalesOrder` vs. the hinted `DBSalesOrder?`) rather than `await`, since
+`GetAsync<T>`-style NHibernate methods are typically annotated to return `Task<T?>`. Ruled out by
+the minimal reproduction above, which involves no nullable types at all (a plain `Task<T>`-returning
+generic factory method) and reproduced the identical miss -- conclusively isolating `await` as the
+actual cause. This also lines up with `SymbolEqualityComparer.Default` (already used by every
+`isTypeSpelledOutIn*` check) being documented to ignore top-level nullable-annotation differences
+when comparing symbols, so a `DBSalesOrder` vs. `DBSalesOrder?` mismatch was never actually a risk
+here in the first place.
+
 ## Configuration Angle
 
 A related (but separate) axis is **making hint kinds configurable** (per the existing TODO

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1,12 +1,12 @@
 # Reducing Superfluous Inlay Hints
 
 **Status:** Full design/rule-table pass for the remaining candidates still not started, but
-informed by six real-world samples (an MVC controller, two large business-logic "ops" classes, a
-companion pair of MVC controller files, a small API controller, and a diverse batch spanning a
-controller/file-I/O utility/Win32 interop/message handler) — see the "Real-World Evidence" sections
-below for concrete label-frequency data pulled from a live `csharp-ls-rpc.log` session, plus a
-source-level root-cause diagnosis of the same-name suppression gap (from reading `InlayHint.fs`
-directly).
+informed by seven real-world samples (an MVC controller, two large business-logic "ops" classes, a
+companion pair of MVC controller files, a small API controller, a diverse batch spanning a
+controller/file-I/O utility/Win32 interop/message handler, and a large private ERP/CRM codebase
+session) — see the "Real-World Evidence" sections below for concrete label-frequency data pulled
+from live `csharp-ls-rpc.log` sessions, plus a source-level root-cause diagnosis of the same-name
+suppression gap (from reading `InlayHint.fs` directly).
 
 Implementation has started against the "Net takeaway" priority ranking below, backed by a new
 `InlayHintTests.fs` (+ dedicated `Fixtures/genericProject/Project/InlayHintTest.cs` fixture, safe
@@ -106,7 +106,40 @@ to keep extending for further rules without touching other tests):
   `Convert.ToInt32(...)`, qualifier `Convert` vs. return type `int`) or an instance (whose
   qualifier symbol is a local/field/property, never a type). Covered by a matching positive/negative
   test pair.
+- ⛔ **Superseded — implicit lambda-parameter type hints removed entirely.** A narrower,
+  shape-based suppression rule (`isTypeSpelledOutInInvocationChainReceiver`) was implemented first
+  (prompted by a seventh real `csharp-ls-rpc.log` session — a large private ERP/CRM codebase —
+  showing individual type-hint labels repeating 249, 138, 51, 45, 36, ... times each in a single
+  response, traced to the `db.Query<DBEntity>().Where(p => ...)` idiom re-hinting `p`'s type on
+  every call even though it's spelled out one call earlier at `Query<DBEntity>`), but a follow-up
+  look at the same file (an entity class, illustrative name `DBOrgEntity.cs`) surfaced further,
+  structurally different instances of the same redundancy that rule wasn't scoped to catch — e.g.
+  `rootUnit.Contacts.OrderBy(x => x.Id).First(x => ...)`, where the identical inferred type
+  (illustrative name `DBContactPerson`) was hinted twice in a row across two chained lambdas with
+  no generic-invocation receiver in sight, and `this.Owner.OrgUnits.Single(b => ...)`, where `b`'s
+  type is trivially inferable from the `.OrgUnits` property name one hop to the left. Asked to
+  justify the hint category in general, and given (a) every real occurrence found across all seven
+  samples turned out to be redundant in one of these shapes, and (b) Visual Studio's own default
+  configuration ships with all inline hints — including this one — off entirely (it's opt-in), the
+  decision (explicit user call) was to stop emitting `InlayHintKind.Type` for implicit lambda
+  parameters altogether, rather than keep chasing individual redundancy shapes. Implemented by
+  deleting the `ParameterSyntax` match arm in `toInlayHint` (and the now-dead
+  `isTypeSpelledOutInInvocationChainReceiver` helper) entirely. The two tests that had covered the
+  narrower rule were replaced with a single regression test asserting no type hint is ever shown
+  for an implicit lambda parameter, covering both the original `Query<T>().Where(p => ...)` shape
+  and a plain non-generic-receiver shape.
 - Rule #7 below is not yet implemented.
+- **Open candidate (not yet implemented):** two-(or-more)-lambda-argument LINQ combinators (e.g.
+  `ToDictionary(keySelector, elementSelector)`, `GroupBy` with an element selector, `ToLookup`,
+  `Join`/`GroupJoin`) still show all their parameter-name hints, since rule #3 above is
+  deliberately scoped to sole-lambda-argument calls only. Confirmed in the same seventh sample
+  (`keySelector:`/`elementSelector:`, 8 occurrences each, from real `ToDictionary(g => g.Key, g =>
+  ...)` call sites). Two design options were discussed but not decided: (a) generalize rule #3 to
+  "every effective argument is a lambda expression" (broader, but risks over-suppressing
+  user-defined multi-lambda methods where position genuinely needs a name, e.g. a hypothetical
+  `Combine(first, second)`), or (b) a narrow allow-list of known `System.Linq.Enumerable`
+  method names with all-lambda arguments (lower risk, needs maintenance). Deferred pending a
+  decision in a future design session.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -119,10 +152,12 @@ function.
 useful to the reader" heuristics:
 
 - **Type hints** (`InlayHintKind.Type`) — for `var` declarations, deconstruction designations,
-  `foreach` loop variables, implicit lambda parameters, and `new(...)` implicit object creation.
-  The only filtering applied today is `validateType`, which suppresses a hint solely when the
-  type fails to resolve (`IErrorTypeSymbol`) or is literally named `"var"`. It does **not**
-  consider whether the type is already obvious from the surrounding code.
+  `foreach` loop variables, and `new(...)` implicit object creation. (Implicit lambda parameters
+  were originally in this list too, but that hint category was removed entirely — see the ⛔
+  **Superseded** entry near the top of this document.) The only filtering applied today is
+  `validateType`, which suppresses a hint solely when the type fails to resolve
+  (`IErrorTypeSymbol`) or is literally named `"var"`. It does **not** consider whether the type is
+  already obvious from the surrounding code.
 - **Parameter name hints** (`InlayHintKind.Parameter`) — for positional call-site arguments.
   The only filtering applied today is `validateParameter`, which suppresses a hint for indexers,
   for parameters with an empty name, or when the argument text already matches the parameter
@@ -688,7 +723,94 @@ Both fixes are independent, small, and additive to the existing `validateParamet
 heuristic categories needed, just making the existing "don't restate what's already in the
 argument's own name" rule actually work in the two most common shapes it currently misses.
 
-**Net takeaway across all six samples:** the highest-value, lowest-risk rules to prioritize
+## Real-World Evidence: Seventh Sample (Large Private ERP/CRM Codebase Session)
+
+A seventh sample, from a live editor session against a large private ERP/CRM codebase (contract
+pricing, product, and device-management "ops"/repository classes), captured via
+`~/csharp-ls-rpc.log`. Unlike the earlier samples' single-file/single-request snapshots, this
+session spanned many `textDocument/inlayHint` responses across several files. Label-frequency
+tally across the whole session, top entries:
+
+| Label | Count | Kind |
+|---|---|---|
+| `: DBLineItemPrice` (illustrative name) / `?` | 249 + 38 | Type |
+| `: DBLineItemCategory` (illustrative name) | 138 | Type |
+| `format:` | 117 | Parameter |
+| `proxy:` | 104 | Parameter |
+| `: DBLineItemDevice` (illustrative name) / `?` | 51 + 21 | Type |
+| `args:` | 54 | Parameter |
+| `: DBArticle` (illustrative name) / `?` | 45 + 10 | Type |
+| `paramName:` | 44 | Parameter |
+| `product:` | 44 | Parameter |
+| `: DBUserCredential` (illustrative name) | 36 | Type |
+| `keySelector:` / `elementSelector:` | 8 each | Parameter |
+| (long tail) | ≤34 each | — |
+
+Three findings: one initially acted on with a narrow fix, then superseded by a full removal after
+a follow-up look at the same file; one left open.
+
+1. **Root cause of the extreme type-hint repetition (249×, 138×, 51×, 45×, 36×, ...): implicit
+   lambda-parameter type hints restating a type already spelled out one call earlier in the same
+   fluent chain.** Every one of these counts traced back to the same data-access idiom, repeated
+   throughout the codebase:
+
+   ```csharp
+   db.Query<DBLineItemPrice>().Where(p => p.SomeCondition)
+   ```
+
+   `p`'s inferred type (`DBLineItemPrice`, illustrative name) was hinted on *every single call*,
+   even though it's spelled out immediately to the left, at `Query<DBLineItemPrice>`. Initially
+   fixed narrowly (a shape-based rule mirroring rule #5, reused against the lambda's enclosing
+   invocation's receiver) — see finding 3 below for why this was superseded.
+2. **Open candidate, not yet implemented: two-lambda-argument LINQ combinators still show all
+   their parameter-name hints.** `keySelector:`/`elementSelector:` (8 occurrences each) come from
+   real `ToDictionary(keySelector, elementSelector)` call sites, e.g.:
+
+   ```csharp
+   .GroupBy(item => item.ReplacedBySerialNumber)
+   .ToDictionary(
+       g => g.Key,
+       g => g.OrderBy(item => item.Revision).Last());
+   ```
+
+   Rule #3 (sole lambda-argument suppression) is *deliberately* scoped to calls with exactly one
+   effective (non-`CancellationToken`) argument, so it correctly does not fire here — confirmed
+   this is working as designed, not a bug, by checking that the single-lambda-argument LINQ case
+   (`predicate:`/`selector:` from `.Where(...)`/`.Select(...)`) produces zero hints anywhere in
+   this session. See the bullet under "Open candidate (not yet implemented)" near the top of this
+   document for the two design options considered for extending coverage to this shape.
+3. **Follow-up on the same file (an entity class, illustrative name `DBOrgEntity.cs`) surfaced
+   further instances of the same redundancy that the narrow fix from finding 1 wasn't scoped to
+   catch, leading to removing the whole hint category.** Two more shapes, both with *no*
+   generic-invocation receiver in sight (so finding 1's fix couldn't have caught them even if
+   generalized slightly):
+
+   ```csharp
+   var primaryContact = rootUnit.Contacts
+       .OrderBy(x => x.Id)
+       .First(x => x.ContactType.Id == DBContactPersonType.ID_DEFAULT);
+   ```
+
+   hinted the *identical* inferred type (illustrative name `DBContactPerson`) twice in a row, once
+   per chained lambda — pure repetition within a few tokens of itself. And:
+
+   ```csharp
+   var rootUnit = this.Owner.OrgUnits.Single(b => b.IsRoot);
+   ```
+
+   hinted `b: DBOrgUnit` (illustrative name), a type trivially inferable from the `.OrgUnits`
+   property name one hop to the left (the `var rootUnit` hint itself was already correctly
+   suppressed here by rule #6, since `rootUnit`'s last word "Unit" echoes the type's last word
+   "Unit" — confirming rule #6 works as intended and isn't the gap). Asked directly to justify
+   keeping the hint category at all, and finding that (a) every real occurrence across all seven
+   samples fell into one of these redundant shapes, and (b) Visual Studio's own default
+   configuration ships with *all* inline hints, including this one, off entirely (opt-in only), the
+   decision was to stop
+   emitting implicit lambda-parameter type hints altogether rather than keep chasing individual
+   redundancy shapes with more narrow rules. See the ⛔ **Superseded** entry near the top of this
+   document for the implementation (a straight deletion of the `ParameterSyntax` match arm).
+
+**Net takeaway across all seven samples:** the highest-value, lowest-risk rules to prioritize
 first, ranked roughly by combined volume, confidence, and implementation risk:
 
 1. **✅ Implemented.** Fix the same-name parameter suppression gap — now root-caused (see above)
@@ -745,11 +867,30 @@ first, ranked roughly by combined volume, confidence, and implementation risk:
 7. Consider suppressing parameter-name hints for arguments to `extern`/P-Invoke-declared methods,
    given their names are typically non-idiomatic, verbatim native-header copies that add little
    without external platform documentation regardless.
+8. **⛔ Superseded by full removal.** Initially implemented narrowly as
+   `isTypeSpelledOutInInvocationChainReceiver` (suppress when the type is already spelled out one
+   call earlier in the same fluent chain, e.g. `db.Query<DBEntity>().Where(p => ...)` — the single
+   biggest-volume finding across all seven samples, accounting for hundreds of hints in the
+   seventh sample alone). A follow-up look at the same file surfaced further redundant shapes this
+   narrow rule wasn't scoped to catch (repeated hints across chained lambdas with no generic
+   receiver at all, e.g. `.OrderBy(x => ...).First(x => ...)`; hints trivially inferable from a
+   property name one hop away, e.g. `.Branches.Single(b => ...)`). Given every real occurrence
+   across all samples turned out redundant, and Visual Studio's own default ships all inline
+   hints — including this one — off entirely, implicit lambda-parameter type hints were removed
+   from `toInlayHint` altogether (the `ParameterSyntax` match arm was deleted, along with the
+   now-dead helper) rather than adding further narrow rules.
+9. **Not yet implemented — open candidate.** Extend coverage to two-(or-more)-lambda-argument LINQ
+   combinators (`ToDictionary(keySelector, elementSelector)`, `GroupBy` with an element selector,
+   `ToLookup`, `Join`/`GroupJoin`), confirmed still fully hinted in the seventh sample. Two
+   untried design options: generalize rule #3 to "every effective argument is a lambda" (broader,
+   riskier for arbitrary user-defined multi-lambda methods) vs. a narrow
+   `System.Linq.Enumerable`-method allow-list (lower risk, more maintenance). Needs a decision
+   before implementation.
 
 The idiom-repetition (suppress-on-known-recurring-callback-shape), idiom-shape (e.g.
 `RedirectToAction`/`View`), qualified-enum-argument idea, and anonymous/tuple-type-verbosity ideas
 remain worth pursuing but are lower-volume, more subjective, and/or a different kind of problem
-(length vs. redundancy) than the seven above. Equally important: this sample reinforced that
+(length vs. redundancy) than the nine above. Equally important: this sample reinforced that
 **negative test cases matter as much as positive ones** — `Stream.Write(buffer, offset, count)`
 and `oldValue`/`newValue`-style handlers are concrete, real examples where hints must be kept.
 
@@ -794,21 +935,30 @@ built-in suppression heuristics is also to be decided during design.
    `isTypeSpelledOutInObjectCreation`, filtering `validateType`'s result in the
    `VariableDeclarationSyntax` match arm alongside `isTypeSpelledOutInGenericInvocation`, with test
    coverage for both the plain-constructor and object-initializer shapes.
-7. Design session to enumerate the exact suppression rule for the one remaining candidate (rule
-   #7 in the "Net takeaway" ranking — `extern`/P-Invoke parameter names — plus any of the
-   lower-priority/subjective ideas from "Candidate Ideas Gathered So Far" worth reconsidering),
-   informed by the real-world evidence above and by user/editor feedback on which current hints
-   still feel noisy in practice.
+6c. ✅ **Done, then superseded.** Implemented rule #8 (implicit lambda-parameter type hints
+   redundant with an immediate generic-invocation receiver) as
+   `isTypeSpelledOutInInvocationChainReceiver`, wired into the `ParameterSyntax` (implicit lambda
+   parameter) type-hint match arm. Written test-first: the positive test
+   (`repository.Query<Widget>().Where(p => ...)`) was confirmed red before wiring the helper in,
+   then green after; the negative control (`chained.Where(p => ...)`, a non-generic receiver)
+   passed throughout. Full `dotnet test` suite (255 tests) confirmed green.
+6d. ✅ **Done.** Superseded 6c: removed implicit lambda-parameter type hints entirely (deleted the
+   `ParameterSyntax` match arm and the now-dead `isTypeSpelledOutInInvocationChainReceiver`
+   helper), per explicit user decision after a follow-up look at the same sample file surfaced
+   further redundant shapes (`.OrderBy(x => ...).First(x => ...)` repeating the same type twice;
+   `.OrgUnits.Single(b => ...)` inferable from the property name) that rule #8 wasn't scoped to
+   catch, and after confirming Visual Studio's own default configuration ships all inline hints
+   off. The two rule-#8-specific tests were replaced with a single regression test asserting no
+   type hint is ever shown for an implicit lambda parameter. Full `dotnet test` suite (254 tests)
+   confirmed green.
+7. Design session to enumerate the exact suppression rule for the two remaining candidates (rule
+   #7 in the "Net takeaway" ranking — `extern`/P-Invoke parameter names — and rule #9 —
+   two-(or-more)-lambda-argument LINQ combinators like `ToDictionary(keySelector,
+   elementSelector)` — plus any of the lower-priority/subjective ideas from "Candidate Ideas
+   Gathered So Far" worth reconsidering), informed by the real-world evidence above and by
+   user/editor feedback on which current hints still feel noisy in practice.
 8. Implement the agreed predicate(s) in `toInlayHint`, with unit/integration test coverage
    (positive case: hint suppressed; negative case: hint still shown for the non-redundant
    variant) — extend the existing `InlayHintTests.fs` / `InlayHintTest.cs` fixture rather than
    creating new ones, so all rules stay exercised against one file.
 9. Decide on and (if wanted) implement the configuration angle above.
-
-## Files Likely Touched
-
-| File | Likely Change |
-|------|----------------|
-| `src/CSharpLanguageServer/Handlers/InlayHint.fs` | Add remaining suppression predicate to `toInlayHint`'s match arms, per the design once finalized (rules #1–#6 already landed/closed) |
-| `tests/CSharpLanguageServer.Tests/InlayHintTests.fs` | Add positive/negative coverage for the remaining rule (rules #1–#6 already covered) |
-| `tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs` | Extend with new code shapes per remaining rule |

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1042,6 +1042,35 @@ type argument matches one of the inferred (constructed generic) type's own type 
 mirroring rule #5's matching logic, just applied one or more calls further to the left instead of
 only at the outermost call.
 
+**Follow-up bug found by re-checking the fix against a second file in the same session: the
+walk didn't unwrap `await`.** The above fix landed with a test-first regression test, but that test
+used a *synchronous* `.ToList()` call for simplicity, not the `await ... .ToListAsync()` shape the
+real evidence actually used. A second handler file (illustrative description) from the same
+session surfaced the gap directly:
+
+```csharp
+var masterOffices = await db.Query<DBBranchOffice>()   // illustrative entity name
+    .Where(o => o.OfficeType == OfficeType.MASTER && o.Enabled)
+    .FetchMany(o => o.Configuration)
+    .ToListAsync();
+```
+
+→ still hinted `": List<DBBranchOffice>?"`, unfixed. The `await` keyword wraps the entire
+invocation chain in an `AwaitExpressionSyntax`, which the chain-walking `walkChain` helper didn't
+know how to see through -- it only unwrapped `ParenthesizedExpressionSyntax`, so `walkChain` was
+being invoked on an `AwaitExpressionSyntax` node at the very first step and immediately fell
+through to its `_ -> false` case, regardless of what was underneath. Since virtually every
+real-world NHibernate `...Async()` call site is awaited, this was a near-total miss for the rule's
+actual intended use case. Fixed by adding an `AwaitExpressionSyntax` unwrap arm to `walkChain`
+(recursing into `await.Expression`), alongside the existing `ParenthesizedExpressionSyntax` unwrap.
+Caught test-first: added a second positive test using the `await ... .ToListAsync()` shape
+end-to-end (a new `ListRepository<T>.ToListAsync()` fixture method returning
+`Task<List<T>>`), confirmed red before the `await`-unwrap fix, green after. This is a good
+reminder that a synthetic test fixture mirroring an initializer-shape rule should match the real
+evidence's *exact* syntactic shape (including `await`), not just its type-level structure -- the
+original fixture's `.ToList()` (no `await`) exercised the new helper's core logic but missed this
+specific, common wrapper.
+
 ## Configuration Angle
 
 A related (but separate) axis is **making hint kinds configurable** (per the existing TODO

--- a/plans/inlay-hint-reduction.md
+++ b/plans/inlay-hint-reduction.md
@@ -1,10 +1,11 @@
 # Reducing Superfluous Inlay Hints
 
 **Status:** Full design/rule-table pass for the remaining candidates still not started, but
-informed by eight real-world samples (an MVC controller, two large business-logic "ops" classes, a
+informed by nine real-world samples (an MVC controller, two large business-logic "ops" classes, a
 companion pair of MVC controller files, a small API controller, a diverse batch spanning a
 controller/file-I/O utility/Win32 interop/message handler, a large private ERP/CRM codebase
-session, and a targeted follow-up spot-check of two more files from that same session) — see the
+session, a targeted follow-up spot-check of two more files from that same session, and a further
+follow-up spot-check of a message/event-processing handler class from that same session) — see the
 "Real-World Evidence" sections below for concrete label-frequency data pulled from live
 `csharp-ls-rpc.log` sessions, plus a source-level root-cause diagnosis of the same-name
 suppression gap (from reading `InlayHint.fs` directly).
@@ -168,6 +169,25 @@ to keep extending for further rules without touching other tests):
   `LiteralExpressionSyntax`, and is deliberately left alone -- covered by a dedicated
   negative-control test). Covered by positive tests for each literal kind plus the interpolated
   string, and the unary-negation negative control.
+- ✅ **New rule (element type spelled out earlier in a fluent invocation chain, redundant `var`
+  type hints on "materializing" calls)** — prompted by a ninth real `csharp-ls-rpc.log` example
+  (see "Ninth Sample" below), `var orders = await
+  db.Query<DBSalesOrder>().Where(o => ...).ToListAsync();` (illustrative entity name), which showed
+  a `": List<DBSalesOrder>?"` hint even though `DBSalesOrder` is already spelled out two calls to
+  the left, at `Query<DBSalesOrder>()`. This is the "materializing-call" sibling of rule #5
+  (`isTypeSpelledOutInGenericInvocation`), which only inspects the initializer's own, outermost
+  invocation's explicit type-argument list -- here the outermost call is `ToListAsync()`, which has
+  no explicit type arguments of its own (its `List<T>` result is entirely inferred from the query).
+  Added `isElementTypeSpelledOutEarlierInInvocationChain`, which fires when the inferred `var` type
+  is a constructed generic type (e.g. `List<DBSalesOrder>`) one of whose own type arguments was
+  already spelled out earlier in the same fluent chain, found by walking the chain's receiver
+  expressions leftwards looking for any earlier invocation's explicit generic type-argument list
+  containing a symbol-equal type. Deliberately doesn't hard-code `ToList`/`ToListAsync`/`ToArray`-
+  style method names as an allow-list -- requiring the inferred type to be a constructed generic
+  type whose element was spelled out is signal enough on its own, and needs no per-method
+  maintenance. Covered by a positive test mirroring the real shape and a negative control where the
+  explicit generic invocation happens in a separate statement (so it's outside this initializer's
+  own invocation chain), which correctly keeps the hint.
 
 **Affects:** `textDocument/inlayHint` — `Handlers/InlayHint.fs`, primarily the `toInlayHint`
 function.
@@ -985,6 +1005,43 @@ Both fixes are small, additive `validateType` filters mirroring the existing
 initializer shapes recognized within the already-established "type is spelled out in the
 initializer" rule family.
 
+## Real-World Evidence: Ninth Sample (Message/Event-Processing Handler Class, Follow-Up)
+
+A further follow-up spot-check of a message/event-processing handler class (illustrative
+description) from the same private ERP/CRM-adjacent codebase session as the seventh and eighth
+samples, captured via `~/csharp-ls-rpc.log`. Like the eighth sample, this was a narrow,
+line-by-line check rather than a broad label-frequency tally -- but it surfaced one more type-hint
+redundancy shape not covered by any of the seven `isTypeSpelledOutIn*`-family rules implemented so
+far.
+
+**The element type of a materialized query result is already spelled out earlier in the same
+fluent chain, but nothing suppressed it.** A handler method followed a common
+"query-then-materialize" idiom:
+
+```csharp
+var orders = await db.Query<DBSalesOrder>()   // illustrative entity name
+    .Where(o =>
+        o.SalesOffice!.Webshop
+        && o.Status == OrderStatus.NewOrder
+        && o.CreateDate >= processFromDate
+        && o.CreateDate < processToDate
+        && o.PendingPayments.Any() == false)
+    .ToListAsync();
+```
+
+→ hinted `": List<DBSalesOrder>?"` on `orders`, even though `DBSalesOrder` is spelled out two calls
+to the left, at `Query<DBSalesOrder>()`, in the very same expression. None of rule #5's existing
+checks caught this: `isTypeSpelledOutInGenericInvocation` only inspects the initializer's own
+*outermost* invocation (`ToListAsync()`, whose `List<DBSalesOrder>` result is entirely inferred --
+it has no explicit type-argument list of its own to check). This is structurally the same
+"redundant with an earlier call in the chain" insight behind the (now-superseded) implicit
+lambda-parameter rule from the seventh sample, but applied to the `var` declaration's own type hint
+instead of a lambda parameter's. The fix, `isElementTypeSpelledOutEarlierInInvocationChain`, walks
+the invocation chain's receivers leftwards looking for an earlier explicit generic invocation whose
+type argument matches one of the inferred (constructed generic) type's own type arguments --
+mirroring rule #5's matching logic, just applied one or more calls further to the left instead of
+only at the outermost call.
+
 ## Configuration Angle
 
 A related (but separate) axis is **making hint kinds configurable** (per the existing TODO
@@ -1042,6 +1099,15 @@ built-in suppression heuristics is also to be decided during design.
    off. The two rule-#8-specific tests were replaced with a single regression test asserting no
    type hint is ever shown for an implicit lambda parameter. Full `dotnet test` suite (254 tests)
    confirmed green.
+6e. ✅ **Done.** Implement rule #5's materializing-call sibling as
+   `isElementTypeSpelledOutEarlierInInvocationChain` (see "Ninth Sample" above), filtering
+   `validateType`'s result in the `VariableDeclarationSyntax` match arm alongside the other
+   `isTypeSpelledOutIn*` checks. Written test-first: the positive test (element type spelled out
+   via an earlier `Query<Widget>()` call in the same chain, materialized via `.ToList()`) was
+   confirmed red before wiring the helper in, then green after; the negative control (the generic
+   invocation happening in a separate statement, outside the initializer's own invocation chain)
+   passed throughout. Full `dotnet test` suite confirmed green (one unrelated, pre-existing
+   timing-flaky test in `JsonRpcTests.fs` aside).
 7. Design session to enumerate the exact suppression rule for the two remaining candidates (rule
    #7 in the "Net takeaway" ranking — `extern`/P-Invoke parameter names — and rule #9 —
    two-(or-more)-lambda-argument LINQ combinators like `ToDictionary(keySelector,

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -167,6 +167,34 @@ module InlayHint =
         String.Equals(identifier, typeName, StringComparison.CurrentCultureIgnoreCase)
         || String.Equals(lastWord identifier, lastWord typeName, StringComparison.CurrentCultureIgnoreCase)
 
+    // A rendered type name longer than this (in characters, not counting the leading ": ") gets
+    // middle-truncated by `truncateMiddle` below rather than shown in full. Most named types
+    // (even fairly descriptive domain entity names) comfortably fit under this; it's compound
+    // types -- anonymous types (`<anonymous type: int Year, int Month, ..., int InvoiceCount>`)
+    // and tuples (`(string Code, string Value, string Name, string UIValue)`) -- that tend to blow
+    // past it, since they grow without bound with the number of members/elements. See
+    // plans/inlay-hint-reduction.md's "anonymous/tuple-type verbosity" follow-up for the
+    // real-world motivation. Module-level so it's easy to find/tune in one place.
+    let private maxTypeHintLabelLength = 40
+
+    // Middle-truncates `s` with a `"..."` ellipsis once it exceeds `maxLength` characters,
+    // otherwise returns it unchanged. Elides the *middle* (rather than just the tail) so both ends
+    // stay visible: the head usually carries the outermost/generic type name (`<anonymous type: `,
+    // `List<`, the leading element name of a tuple, ...), while the tail often carries the last,
+    // sometimes most-distinguishing member/element (`..., int InvoiceCount>`). Splits the
+    // available (non-ellipsis) budget as evenly as possible between head and tail, biasing any odd
+    // leftover character to the head. `maxLength` values too small to fit even the ellipsis itself
+    // degrade gracefully to the ellipsis alone (or less), rather than throwing.
+    let private truncateMiddle (maxLength: int) (s: string) : string =
+        if s.Length <= maxLength then
+            s
+        else
+            let ellipsis = "..."
+            let keep = max 0 (maxLength - ellipsis.Length)
+            let headLen = (keep + 1) / 2
+            let tailLen = keep - headLen
+            s.Substring(0, headLen) + ellipsis + s.Substring(s.Length - tailLen, tailLen)
+
     let private toInlayHint
         (semanticModel: SemanticModel)
         (lines: TextLineCollection)
@@ -209,11 +237,21 @@ module InlayHint =
             )
 
         let toTypeInlayHint (pos: int) (ty: ITypeSymbol) : InlayHint =
+            let fullTypeName = SymbolName.fromSymbol typeDisplayStyle ty
+            let displayTypeName = truncateMiddle maxTypeHintLabelLength fullTypeName
+
             { Position = pos |> lines.GetLinePosition |> Position.fromLinePosition
-              Label = U2.C1(": " + SymbolName.fromSymbol typeDisplayStyle ty)
+              Label = U2.C1(": " + displayTypeName)
               Kind = Some InlayHintKind.Type
               TextEdits = None
-              Tooltip = None
+              // When the label was truncated, surface the full, untruncated type name as the
+              // hint's hover tooltip, so the information eliding the middle removed from the
+              // label is still just a hover away rather than lost entirely.
+              Tooltip =
+                if displayTypeName <> fullTypeName then
+                    Some(U2.C1 fullTypeName)
+                else
+                    None
               PaddingLeft = Some false
               PaddingRight = Some false
               Data = None }

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -33,6 +33,34 @@ module InlayHint =
 
         best |> Option.orElse all |> Option.defaultValue Array.empty
 
+    // Extracts the `IParameterSymbol`s of a single, unambiguously-resolved method/indexer symbol
+    // (as returned by `getBestOrAllSymbols` above), or an empty array when resolution was
+    // ambiguous (more/less than one candidate) or resolved to a non-parameterized symbol kind.
+    // Shared by `getParameterForArgumentSyntax` and `getParameterForAttributeArgumentSyntax`
+    // below, which otherwise duplicated this resolution verbatim. Deliberately returns an empty
+    // array rather than `None` in the ambiguous case (instead of the original short-circuiting
+    // `match symbols with | [| symbol |] -> ... | _ -> None`): every parameter lookup against an
+    // empty array below already naturally yields `None` on its own, so the two are behaviorally
+    // identical, without needing to thread an extra `option` layer through both callers.
+    let private parametersOfSingleResolvedSymbol (symbols: ISymbol[]) : ImmutableArray<IParameterSymbol> =
+        match symbols with
+        | [| :? IMethodSymbol as m |] -> m.Parameters
+        | [| :? IPropertySymbol as nt |] -> nt.Parameters
+        | _ -> ImmutableArray<IParameterSymbol>.Empty
+
+    // Resolves a `NameColon` (`name: value`)-style named argument (`argument: Foo(name: value)`,
+    // `attributeArgument: [Attr(name: value)]`) against `parameters` by name. Shared by
+    // `getParameterForArgumentSyntax` and `getParameterForAttributeArgumentSyntax` below, which
+    // otherwise duplicated this resolution verbatim.
+    let private tryNamedParameter
+        (parameters: ImmutableArray<IParameterSymbol>)
+        (nameColon: NameColonSyntax)
+        : IParameterSymbol option =
+        nameColon
+        |> Option.ofObj
+        |> Option.bind (fun anc -> if anc.IsMissing then None else Some anc)
+        |> Option.bind (fun anc -> parameters |> Seq.tryFind (fun p -> p.Name = anc.Name.Identifier.ValueText))
+
     // rewrite of https://github.com/dotnet/roslyn/blob/main/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/ArgumentSyntaxExtensions.cs
     let private getParameterForArgumentSyntax
         (semanticModel: SemanticModel)
@@ -41,41 +69,31 @@ module InlayHint =
         match argument.Parent with
         | :? BaseArgumentListSyntax as argumentList when not (isNull argumentList.Parent) ->
             let argumentListParent = argumentList.Parent |> nonNull "argumentList.Parent"
-            let symbols = semanticModel.GetSymbolInfo(argumentListParent) |> getBestOrAllSymbols
 
-            match symbols with
-            | [| symbol |] ->
-                let parameters =
-                    match symbol with
-                    | :? IMethodSymbol as m -> m.Parameters
-                    | :? IPropertySymbol as nt -> nt.Parameters
-                    | _ -> ImmutableArray<IParameterSymbol>.Empty
+            let parameters =
+                semanticModel.GetSymbolInfo(argumentListParent)
+                |> getBestOrAllSymbols
+                |> parametersOfSingleResolvedSymbol
 
-                let namedParameter =
-                    argument.NameColon
-                    |> Option.ofObj
-                    |> Option.bind (fun anc -> if anc.IsMissing then None else Some anc)
-                    |> Option.bind (fun anc ->
-                        parameters |> Seq.tryFind (fun p -> p.Name = anc.Name.Identifier.ValueText))
+            let namedParameter = tryNamedParameter parameters argument.NameColon
 
-                let positionalParameter =
-                    match argumentList.Arguments.IndexOf(argument) with
-                    | index when 0 <= index && index < parameters.Length ->
-                        let parameter = parameters[index]
+            let positionalParameter =
+                match argumentList.Arguments.IndexOf(argument) with
+                | index when 0 <= index && index < parameters.Length ->
+                    let parameter = parameters[index]
 
-                        if
-                            argument.RefOrOutKeyword.Kind() = SyntaxKind.OutKeyword
-                            && parameter.RefKind <> RefKind.Out
-                            || argument.RefOrOutKeyword.Kind() = SyntaxKind.RefKeyword
-                               && parameter.RefKind <> RefKind.Ref
-                        then
-                            None
-                        else
-                            Some parameter
-                    | _ -> None
+                    if
+                        argument.RefOrOutKeyword.Kind() = SyntaxKind.OutKeyword
+                        && parameter.RefKind <> RefKind.Out
+                        || argument.RefOrOutKeyword.Kind() = SyntaxKind.RefKeyword
+                           && parameter.RefKind <> RefKind.Ref
+                    then
+                        None
+                    else
+                        Some parameter
+                | _ -> None
 
-                namedParameter |> Option.orElse positionalParameter
-            | _ -> None
+            namedParameter |> Option.orElse positionalParameter
         | _ -> None
 
     // rewrite of https://github.com/dotnet/roslyn/blob/main/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Extensions/AttributeArgumentSyntaxExtensions.cs
@@ -87,30 +105,19 @@ module InlayHint =
         | :? AttributeArgumentListSyntax as argumentList when not (isNull argument.NameEquals) ->
             match argumentList.Parent with
             | :? AttributeSyntax as invocable ->
-                let symbols = semanticModel.GetSymbolInfo(invocable) |> getBestOrAllSymbols
+                let parameters =
+                    semanticModel.GetSymbolInfo(invocable)
+                    |> getBestOrAllSymbols
+                    |> parametersOfSingleResolvedSymbol
 
-                match symbols with
-                | [| symbol |] ->
-                    let parameters =
-                        match symbol with
-                        | :? IMethodSymbol as m -> m.Parameters
-                        | :? IPropertySymbol as nt -> nt.Parameters
-                        | _ -> ImmutableArray<IParameterSymbol>.Empty
+                let namedParameter = tryNamedParameter parameters argument.NameColon
 
-                    let namedParameter =
-                        argument.NameColon
-                        |> Option.ofObj
-                        |> Option.bind (fun anc -> if anc.IsMissing then None else Some anc)
-                        |> Option.bind (fun anc ->
-                            parameters |> Seq.tryFind (fun p -> p.Name = anc.Name.Identifier.ValueText))
+                let positionalParameter =
+                    match argumentList.Arguments.IndexOf(argument) with
+                    | index when 0 <= index && index < parameters.Length -> Some parameters[index]
+                    | _ -> None
 
-                    let positionalParameter =
-                        match argumentList.Arguments.IndexOf(argument) with
-                        | index when 0 <= index && index < parameters.Length -> Some parameters[index]
-                        | _ -> None
-
-                    namedParameter |> Option.orElse positionalParameter
-                | _ -> None
+                namedParameter |> Option.orElse positionalParameter
             | _ -> None
         | _ -> None
 
@@ -195,6 +202,39 @@ module InlayHint =
             let tailLen = keep - headLen
             s.Substring(0, headLen) + ellipsis + s.Substring(s.Length - tailLen, tailLen)
 
+    // Extracts the explicit `GenericNameSyntax` callee of an invocation, whether the invocation is
+    // itself a bare generic call (`Foo<T>()`) or a generic member access (`x.Foo<T>()`) -- i.e. so
+    // its explicit type-argument list (`Foo<T>`'s `<T>`) can be inspected. Returns `None` for a
+    // non-generic invocation (e.g. `x.Foo()`). Shared by `isTypeSpelledOutInGenericInvocation` and
+    // `isElementTypeSpelledOutEarlierInInvocationChain`'s chain walk below, which both need to
+    // find an invocation's own explicit type-argument list -- just at different points in an
+    // expression (the initializer's own outermost invocation vs. an arbitrary earlier call
+    // further along the same fluent chain).
+    let private genericNameOfInvocation (invocation: InvocationExpressionSyntax) : GenericNameSyntax option =
+        match invocation.Expression with
+        | :? GenericNameSyntax as generic -> Some generic
+        | :? MemberAccessExpressionSyntax as memberAccess ->
+            match memberAccess.Name with
+            | :? GenericNameSyntax as generic -> Some generic
+            | _ -> None
+        | _ -> None
+
+    // True when `generic`'s explicit type-argument list contains at least one type symbol
+    // satisfying `matches`. Shared by `isTypeSpelledOutInGenericInvocation` (which matches against
+    // a single, fixed `ty`) and `isElementTypeSpelledOutEarlierInInvocationChain`'s chain walk
+    // (which matches against any of a constructed generic type's own type arguments) -- both
+    // otherwise duplicated this exact type-argument resolution/comparison loop.
+    let private genericInvocationTypeArgumentMatches
+        (semanticModel: SemanticModel)
+        (matches: ITypeSymbol -> bool)
+        (generic: GenericNameSyntax)
+        : bool =
+        generic.TypeArgumentList.Arguments
+        |> Seq.exists (fun typeArgSyntax ->
+            match semanticModel.GetTypeInfo(typeArgSyntax).Type |> Option.ofObj with
+            | Some typeArgSymbol -> matches typeArgSymbol
+            | None -> false)
+
     let private toInlayHint
         (semanticModel: SemanticModel)
         (lines: TextLineCollection)
@@ -262,29 +302,20 @@ module InlayHint =
         // that case a `var` type hint would be purely redundant, since the type is already
         // spelled out one step to the left in the very same expression (`Enum.Parse<`,
         // `JsonSerializer.Deserialize<`, `Activator.CreateInstance<`, a local factory method,
-        // ...). Parenthesized expressions are unwrapped. Compares by symbol (not just by name),
-        // so it correctly doesn't fire when the invocation's return type differs from its type
-        // argument (e.g. a hypothetical `Describe<Widget>(...)` returning `string`).
-        let rec isTypeSpelledOutInGenericInvocation (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+        // ...). Compares by symbol (not just by name), so it correctly doesn't fire when the
+        // invocation's return type differs from its type argument (e.g. a hypothetical
+        // `Describe<Widget>(...)` returning `string`). `initializer` is expected to already be
+        // unwrapped (see `unwrapAwaitAndParens` above) -- this only checks the immediate, top-level
+        // shape, it doesn't search recursively.
+        let isTypeSpelledOutInGenericInvocation (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
             match initializer with
-            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInGenericInvocation paren.Expression ty
             | :? InvocationExpressionSyntax as invocation ->
-                let genericName =
-                    match invocation.Expression with
-                    | :? GenericNameSyntax as generic -> Some generic
-                    | :? MemberAccessExpressionSyntax as memberAccess ->
-                        match memberAccess.Name with
-                        | :? GenericNameSyntax as generic -> Some generic
-                        | _ -> None
-                    | _ -> None
-
-                genericName
-                |> Option.map (fun generic ->
-                    generic.TypeArgumentList.Arguments
-                    |> Seq.exists (fun typeArgSyntax ->
-                        match semanticModel.GetTypeInfo(typeArgSyntax).Type |> Option.ofObj with
-                        | Some typeArgSymbol -> SymbolEqualityComparer.Default.Equals(typeArgSymbol, ty)
-                        | None -> false))
+                invocation
+                |> genericNameOfInvocation
+                |> Option.map (
+                    genericInvocationTypeArgumentMatches semanticModel (fun typeArgSymbol ->
+                        SymbolEqualityComparer.Default.Equals(typeArgSymbol, ty))
+                )
                 |> Option.defaultValue false
             | _ -> false
 
@@ -303,41 +334,31 @@ module InlayHint =
         // in the very same expression. Walks the invocation chain leftwards (each invocation's own
         // receiver, when that receiver is itself an invocation reached through a member access)
         // looking for any explicit generic invocation whose type-argument list contains a type
-        // symbol-equal to one of `ty`'s type arguments. Parenthesized expressions are unwrapped.
-        // Deliberately does not require the outermost call to be a specific, named method (e.g.
-        // `ToList`/`ToListAsync`/`ToArray`) -- restricting to `ty` being a *constructed generic*
-        // type whose element was spelled out is enough of a signal on its own, and avoids having
-        // to maintain a per-method allow-list.
-        let rec isElementTypeSpelledOutEarlierInInvocationChain
-            (initializer: ExpressionSyntax)
-            (ty: ITypeSymbol)
-            : bool =
+        // symbol-equal to one of `ty`'s type arguments (parenthesized sub-expressions encountered
+        // along the way are unwrapped too). Deliberately does not require the outermost call to be
+        // a specific, named method (e.g. `ToList`/`ToListAsync`/`ToArray`) -- restricting to `ty`
+        // being a *constructed generic* type whose element was spelled out is enough of a signal
+        // on its own, and avoids having to maintain a per-method allow-list.
+        let isElementTypeSpelledOutEarlierInInvocationChain (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
             match ty with
             | :? INamedTypeSymbol as namedTy when not namedTy.TypeArguments.IsEmpty ->
+                let elementTypeMatches (typeArgSymbol: ITypeSymbol) =
+                    namedTy.TypeArguments
+                    |> Seq.exists (fun elemTy -> SymbolEqualityComparer.Default.Equals(elemTy, typeArgSymbol))
+
                 let rec walkChain (expr: ExpressionSyntax) : bool =
                     match expr with
+                    // Unlike the top-level `isTypeSpelledOutIn*` checks above (which are only ever
+                    // called once, with an already-unwrapped expression -- see
+                    // `unwrapAwaitAndParens`), this walk can revisit a parenthesized sub-expression
+                    // at any point while descending through the chain's receivers, so it still
+                    // needs its own unwrap here.
                     | :? ParenthesizedExpressionSyntax as paren -> walkChain paren.Expression
                     | :? InvocationExpressionSyntax as invocation ->
-                        let genericName =
-                            match invocation.Expression with
-                            | :? GenericNameSyntax as generic -> Some generic
-                            | :? MemberAccessExpressionSyntax as memberAccess ->
-                                match memberAccess.Name with
-                                | :? GenericNameSyntax as generic -> Some generic
-                                | _ -> None
-                            | _ -> None
-
                         let spelledOutHere =
-                            genericName
-                            |> Option.map (fun generic ->
-                                generic.TypeArgumentList.Arguments
-                                |> Seq.exists (fun typeArgSyntax ->
-                                    match semanticModel.GetTypeInfo(typeArgSyntax).Type |> Option.ofObj with
-                                    | Some typeArgSymbol ->
-                                        namedTy.TypeArguments
-                                        |> Seq.exists (fun elemTy ->
-                                            SymbolEqualityComparer.Default.Equals(elemTy, typeArgSymbol))
-                                    | None -> false))
+                            invocation
+                            |> genericNameOfInvocation
+                            |> Option.map (genericInvocationTypeArgumentMatches semanticModel elementTypeMatches)
                             |> Option.defaultValue false
 
                         if spelledOutHere then
@@ -356,18 +377,16 @@ module InlayHint =
         // `ty` -- in that case a `var` type hint would be purely redundant, since the type is
         // already spelled out immediately after `new`, one step to the left in the very same
         // expression (mirrors `isTypeSpelledOutInGenericInvocation` above, but for plain
-        // object-creation rather than an explicit generic type argument). Parenthesized
-        // expressions are unwrapped. Deliberately restricted to explicit
-        // `ObjectCreationExpressionSyntax` -- NOT `ImplicitObjectCreationExpressionSyntax`
+        // object-creation rather than an explicit generic type argument). Deliberately restricted
+        // to explicit `ObjectCreationExpressionSyntax` -- NOT `ImplicitObjectCreationExpressionSyntax`
         // (target-typed `new()`), where the type is *not* spelled out and the hint remains the
         // useful, intended case (handled separately, right after `new`, by the
         // `ImplicitObjectCreationExpressionSyntax` match arm below). Compares by symbol so it
         // doesn't fire on a mismatching type (e.g. an upcast via `as`, which isn't unwrapped
         // here, so its `ObjectCreationExpressionSyntax` operand is never reached in the first
         // place).
-        let rec isTypeSpelledOutInObjectCreation (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+        let isTypeSpelledOutInObjectCreation (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
             match initializer with
-            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInObjectCreation paren.Expression ty
             | :? ObjectCreationExpressionSyntax as objectCreation ->
                 match semanticModel.GetTypeInfo(objectCreation.Type).Type |> Option.ofObj with
                 | Some createdType -> SymbolEqualityComparer.Default.Equals(createdType, ty)
@@ -379,18 +398,16 @@ module InlayHint =
         // ...) where that qualifying type is itself symbol-equal to `ty` -- in that case a `var`
         // type hint would be purely redundant, since the type is already spelled out immediately
         // to the left of `.` in the very same expression (the qualifier-based sibling of
-        // `isTypeSpelledOutInGenericInvocation`'s type-argument-based check above). Parenthesized
-        // expressions are unwrapped. `GetSymbolInfo` (not `GetTypeInfo`) is used on the qualifier
-        // because a type used as a static-member-access receiver doesn't have a "value type" of
-        // its own -- its symbol *is* the type. Compares by symbol, so it correctly doesn't fire
-        // when the qualifier is an unrelated type whose name doesn't match the return type (e.g.
-        // `Convert.ToInt32(...)`, qualifier `Convert` vs. return type `int`) or when the qualifier
-        // is an instance (a local/field/property access resolves to that member's symbol, not a
-        // type, so it never matches `:? ITypeSymbol`).
-        let rec isTypeSpelledOutInStaticInvocationQualifier (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+        // `isTypeSpelledOutInGenericInvocation`'s type-argument-based check above). `GetSymbolInfo`
+        // (not `GetTypeInfo`) is used on the qualifier because a type used as a
+        // static-member-access receiver doesn't have a "value type" of its own -- its symbol *is*
+        // the type. Compares by symbol, so it correctly doesn't fire when the qualifier is an
+        // unrelated type whose name doesn't match the return type (e.g. `Convert.ToInt32(...)`,
+        // qualifier `Convert` vs. return type `int`) or when the qualifier is an instance (a
+        // local/field/property access resolves to that member's symbol, not a type, so it never
+        // matches `:? ITypeSymbol`).
+        let isTypeSpelledOutInStaticInvocationQualifier (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
             match initializer with
-            | :? ParenthesizedExpressionSyntax as paren ->
-                isTypeSpelledOutInStaticInvocationQualifier paren.Expression ty
             | :? InvocationExpressionSyntax as invocation ->
                 match invocation.Expression with
                 | :? MemberAccessExpressionSyntax as memberAccess ->
@@ -404,16 +421,14 @@ module InlayHint =
         // is symbol-equal to `ty` -- in that case a `var` type hint would be purely redundant,
         // since the type is already spelled out immediately after `as`, in the very same
         // expression (a real example: `obj as DBBankAccount` (illustrative name), from a private
-        // codebase's `Equals` override, cited in plans/inlay-hint-reduction.md). Parenthesized
-        // expressions are unwrapped.
+        // codebase's `Equals` override, cited in plans/inlay-hint-reduction.md).
         // `GetSymbolInfo` (not `GetTypeInfo`) is used on the right-hand side for the same reason
         // as `isTypeSpelledOutInStaticInvocationQualifier` above: it's a type reference, not a
         // value-producing expression, so it has no "value type" of its own -- its symbol *is* the
         // type. Mirrors Roslyn's own `CSharpInlineTypeHintsService`'s `BinaryExpressionSyntax`
         // with `AsExpression` kind candidate (see plans/inlay-hint-reduction.md).
-        let rec isTypeSpelledOutInAsExpression (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+        let isTypeSpelledOutInAsExpression (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
             match initializer with
-            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInAsExpression paren.Expression ty
             | :? BinaryExpressionSyntax as binary when binary.Kind() = SyntaxKind.AsExpression ->
                 match semanticModel.GetSymbolInfo(binary.Right).Symbol |> Option.ofObj with
                 | Some(:? ITypeSymbol as castType) -> SymbolEqualityComparer.Default.Equals(castType, ty)
@@ -426,20 +441,18 @@ module InlayHint =
         // declaration never provides -- is always `string`) -- in either case a `var` type hint
         // would be purely redundant, since the type is directly implied by the initializer's own
         // syntax (`var x = "hi"` and `var x = $"hi {name}"` are both obviously `string`, `var x =
-        // 42` is obviously `int`, ...). Parenthesized expressions are unwrapped. Deliberately
-        // excludes the `null` literal (its type can't be inferred from the literal alone -- it
-        // could be any reference/nullable-value type) and the `default` literal (same reasoning,
-        // plus it's its own distinct syntax node, DefaultExpressionSyntax, not
-        // LiteralExpressionSyntax). Also deliberately narrow about *which* expressions count:
-        // e.g. a unary-negated numeric literal (`var x = -1`) is a PrefixUnaryExpressionSyntax,
-        // not itself a LiteralExpressionSyntax, so it's intentionally left alone by this rule.
-        // See plans/inlay-hint-reduction.md's "LiteralExpressionSyntax" Roslyn prior-art candidate
-        // and the real interpolated-string example from a private codebase's trace/log-handler
-        // class (illustrative name) that prompted extending it to interpolated strings too.
-        let rec isTypeSpelledOutInLiteralOrInterpolatedString (initializer: ExpressionSyntax) : bool =
+        // 42` is obviously `int`, ...). Deliberately excludes the `null` literal (its type can't
+        // be inferred from the literal alone -- it could be any reference/nullable-value type) and
+        // the `default` literal (same reasoning, plus it's its own distinct syntax node,
+        // DefaultExpressionSyntax, not LiteralExpressionSyntax). Also deliberately narrow about
+        // *which* expressions count: e.g. a unary-negated numeric literal (`var x = -1`) is a
+        // PrefixUnaryExpressionSyntax, not itself a LiteralExpressionSyntax, so it's intentionally
+        // left alone by this rule. See plans/inlay-hint-reduction.md's "LiteralExpressionSyntax"
+        // Roslyn prior-art candidate and the real interpolated-string example from a private
+        // codebase's trace/log-handler class (illustrative name) that prompted extending it to
+        // interpolated strings too.
+        let isTypeSpelledOutInLiteralOrInterpolatedString (initializer: ExpressionSyntax) : bool =
             match initializer with
-            | :? ParenthesizedExpressionSyntax as paren ->
-                isTypeSpelledOutInLiteralOrInterpolatedString paren.Expression
             | :? InterpolatedStringExpressionSyntax -> true
             | :? LiteralExpressionSyntax as literal ->
                 match literal.Kind() with

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -181,6 +181,24 @@ module InlayHint =
                 else
                     Some ty
 
+        // Strips `await` (and parenthesization) off the *outside* of a `var` initializer before
+        // any of the `isTypeSpelledOutIn*` shape checks below inspect it. `await` can only ever
+        // wrap the entire initializer expression once, at the very outside (you can't call more
+        // members after awaiting mid-chain -- `await x.Foo().Bar()` awaits the whole `Foo().Bar()`
+        // chain's result at the end, not `x.Foo()` alone), so a single, shared, top-level unwrap
+        // here covers every one of the `isTypeSpelledOutIn*` checks without each of them needing
+        // their own `AwaitExpressionSyntax` case. Almost every real-world async data-access call
+        // site is awaited (e.g. `await db.GetAsync<T>(id)`, `await
+        // db.Query<T>().Where(...).ToListAsync()`), so without this, every one of those checks
+        // would silently fall through to its default "not spelled out" case and needlessly keep
+        // the hint -- see plans/inlay-hint-reduction.md for two real, independently-discovered
+        // examples of exactly this gap.
+        let rec unwrapAwaitAndParens (expr: ExpressionSyntax) : ExpressionSyntax =
+            match expr with
+            | :? AwaitExpressionSyntax as await -> unwrapAwaitAndParens await.Expression
+            | :? ParenthesizedExpressionSyntax as paren -> unwrapAwaitAndParens paren.Expression
+            | _ -> expr
+
         let typeDisplayStyle =
             SymbolDisplayFormat(
                 genericsOptions = SymbolDisplayGenericsOptions.IncludeTypeParameters,
@@ -261,12 +279,6 @@ module InlayHint =
                 let rec walkChain (expr: ExpressionSyntax) : bool =
                     match expr with
                     | :? ParenthesizedExpressionSyntax as paren -> walkChain paren.Expression
-                    // The far-and-away most common real-world shape of this idiom is `await
-                    // db.Query<T>().Where(...)....ToListAsync()` -- unwrap the `await` so the
-                    // invocation chain underneath it is still reached (otherwise every awaited
-                    // call site, i.e. virtually every real NHibernate `...Async()` call, would
-                    // silently fall through to the `_ -> false` case below and keep its hint).
-                    | :? AwaitExpressionSyntax as await -> walkChain await.Expression
                     | :? InvocationExpressionSyntax as invocation ->
                         let genericName =
                             match invocation.Expression with
@@ -530,12 +542,14 @@ module InlayHint =
                 var.Variables[0].Initializer
                 |> Option.ofObj
                 |> Option.map (fun eq ->
-                    not (isTypeSpelledOutInGenericInvocation eq.Value ty)
-                    && not (isTypeSpelledOutInObjectCreation eq.Value ty)
-                    && not (isTypeSpelledOutInStaticInvocationQualifier eq.Value ty)
-                    && not (isTypeSpelledOutInAsExpression eq.Value ty)
-                    && not (isTypeSpelledOutInLiteralOrInterpolatedString eq.Value)
-                    && not (isElementTypeSpelledOutEarlierInInvocationChain eq.Value ty))
+                    let initializerValue = unwrapAwaitAndParens eq.Value
+
+                    not (isTypeSpelledOutInGenericInvocation initializerValue ty)
+                    && not (isTypeSpelledOutInObjectCreation initializerValue ty)
+                    && not (isTypeSpelledOutInStaticInvocationQualifier initializerValue ty)
+                    && not (isTypeSpelledOutInAsExpression initializerValue ty)
+                    && not (isTypeSpelledOutInLiteralOrInterpolatedString initializerValue)
+                    && not (isElementTypeSpelledOutEarlierInInvocationChain initializerValue ty))
                 |> Option.defaultValue true)
             // Don't show hint if the variable's own identifier already echoes the type name
             // (`resourceCondition`/`settingChangeCondition` vs. `ResourceCondition`)

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -446,17 +446,14 @@ module InlayHint =
             |> validateType
             |> Option.filter (fun ty -> not (identifierEchoesTypeName forEach.Identifier.ValueText ty.Name))
             |> Option.map (toTypeInlayHint forEach.Identifier.Span.End)
-        | :? ParameterSyntax as parameterNode when isNull parameterNode.Type ->
-            let parameter = semanticModel.GetDeclaredSymbol(parameterNode)
-
-            parameter
-            |> fun parameter ->
-                match parameter.ContainingSymbol with
-                | :? IMethodSymbol as methSym when methSym.MethodKind = MethodKind.AnonymousFunction -> Some parameter
-                | _ -> None
-            |> Option.map (fun parameter -> parameter.Type)
-            |> Option.bind validateType
-            |> Option.map (toTypeInlayHint parameterNode.Identifier.Span.End)
+        // Deliberately no longer emitting implicit lambda-parameter type hints (the
+        // `(p: DBEntity) => ...` style hint) at all -- see plans/inlay-hint-reduction.md for the
+        // rationale: real-world evidence across multiple samples showed this hint category is
+        // almost always redundant (spelled out by an immediately-preceding generic invocation,
+        // inferable from a property access one hop to the left, or simply repeated identically
+        // for the same type across multiple lambdas in one short fluent chain), and Visual
+        // Studio's own default configuration ships with all inline hints -- including this one --
+        // off by default.
         | :? ImplicitObjectCreationExpressionSyntax as implicitNew ->
             semanticModel.GetTypeInfo(implicitNew).Type
             |> validateType

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -261,6 +261,12 @@ module InlayHint =
                 let rec walkChain (expr: ExpressionSyntax) : bool =
                     match expr with
                     | :? ParenthesizedExpressionSyntax as paren -> walkChain paren.Expression
+                    // The far-and-away most common real-world shape of this idiom is `await
+                    // db.Query<T>().Where(...)....ToListAsync()` -- unwrap the `await` so the
+                    // invocation chain underneath it is still reached (otherwise every awaited
+                    // call site, i.e. virtually every real NHibernate `...Async()` call, would
+                    // silently fall through to the `_ -> false` case below and keep its hint).
+                    | :? AwaitExpressionSyntax as await -> walkChain await.Expression
                     | :? InvocationExpressionSyntax as invocation ->
                         let genericName =
                             match invocation.Expression with

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -232,6 +232,69 @@ module InlayHint =
                 |> Option.defaultValue false
             | _ -> false
 
+        // Returns true when `ty` is a constructed generic type (e.g. `List<DBSalesOrder>`) and
+        // one of its own type arguments (e.g. `DBSalesOrder`) was already spelled out *earlier* in
+        // the same fluent invocation chain that produced `initializer`, via an explicit generic
+        // invocation's type-argument list -- the materializing-call sibling of
+        // `isTypeSpelledOutInGenericInvocation` above, which only looks at the initializer's own,
+        // outermost invocation. A real example (illustrative names, see
+        // plans/inlay-hint-reduction.md): `var orders = await
+        // db.Query<DBSalesOrder>().Where(o => ...).ToListAsync();` -- the outermost invocation is
+        // `ToListAsync()`, which has no explicit type arguments of its own (its `List<DBSalesOrder>`
+        // result is entirely inferred), so `isTypeSpelledOutInGenericInvocation` doesn't catch
+        // this shape. But `DBSalesOrder` -- one of the inferred `List<DBSalesOrder>` type's own
+        // type arguments -- is still spelled out two calls to the left, at `Query<DBSalesOrder>()`,
+        // in the very same expression. Walks the invocation chain leftwards (each invocation's own
+        // receiver, when that receiver is itself an invocation reached through a member access)
+        // looking for any explicit generic invocation whose type-argument list contains a type
+        // symbol-equal to one of `ty`'s type arguments. Parenthesized expressions are unwrapped.
+        // Deliberately does not require the outermost call to be a specific, named method (e.g.
+        // `ToList`/`ToListAsync`/`ToArray`) -- restricting to `ty` being a *constructed generic*
+        // type whose element was spelled out is enough of a signal on its own, and avoids having
+        // to maintain a per-method allow-list.
+        let rec isElementTypeSpelledOutEarlierInInvocationChain
+            (initializer: ExpressionSyntax)
+            (ty: ITypeSymbol)
+            : bool =
+            match ty with
+            | :? INamedTypeSymbol as namedTy when not namedTy.TypeArguments.IsEmpty ->
+                let rec walkChain (expr: ExpressionSyntax) : bool =
+                    match expr with
+                    | :? ParenthesizedExpressionSyntax as paren -> walkChain paren.Expression
+                    | :? InvocationExpressionSyntax as invocation ->
+                        let genericName =
+                            match invocation.Expression with
+                            | :? GenericNameSyntax as generic -> Some generic
+                            | :? MemberAccessExpressionSyntax as memberAccess ->
+                                match memberAccess.Name with
+                                | :? GenericNameSyntax as generic -> Some generic
+                                | _ -> None
+                            | _ -> None
+
+                        let spelledOutHere =
+                            genericName
+                            |> Option.map (fun generic ->
+                                generic.TypeArgumentList.Arguments
+                                |> Seq.exists (fun typeArgSyntax ->
+                                    match semanticModel.GetTypeInfo(typeArgSyntax).Type |> Option.ofObj with
+                                    | Some typeArgSymbol ->
+                                        namedTy.TypeArguments
+                                        |> Seq.exists (fun elemTy ->
+                                            SymbolEqualityComparer.Default.Equals(elemTy, typeArgSymbol))
+                                    | None -> false))
+                            |> Option.defaultValue false
+
+                        if spelledOutHere then
+                            true
+                        else
+                            match invocation.Expression with
+                            | :? MemberAccessExpressionSyntax as memberAccess -> walkChain memberAccess.Expression
+                            | _ -> false
+                    | _ -> false
+
+                walkChain initializer
+            | _ -> false
+
         // Returns true when `initializer` is an explicit object-creation expression (`new
         // SomeType(...)` / `new SomeType { ... }`) whose spelled-out type is symbol-equal to
         // `ty` -- in that case a `var` type hint would be purely redundant, since the type is
@@ -452,9 +515,11 @@ module InlayHint =
             // object-creation expression that already spells out this exact type (`new
             // SomeType(...)` / `new SomeType { ... }`), a static invocation qualified by this
             // exact type's own name (`string.Format(...)`, `Guid.NewGuid()`, ...), an `as` cast to
-            // this exact type (`obj as SomeType`), or a literal/interpolated-string expression
-            // whose type is directly implied by its own syntax (`"hi"`, `42`, `true`, `$"hi
-            // {name}"`, ...)
+            // this exact type (`obj as SomeType`), a literal/interpolated-string expression whose
+            // type is directly implied by its own syntax (`"hi"`, `42`, `true`, `$"hi {name}"`,
+            // ...), or a constructed generic type (e.g. `List<DBSalesOrder>`) one of whose own
+            // type arguments was already spelled out earlier in the same fluent invocation chain
+            // (e.g. `db.Query<DBSalesOrder>().Where(...).ToListAsync()`)
             |> Option.filter (fun ty ->
                 var.Variables[0].Initializer
                 |> Option.ofObj
@@ -463,7 +528,8 @@ module InlayHint =
                     && not (isTypeSpelledOutInObjectCreation eq.Value ty)
                     && not (isTypeSpelledOutInStaticInvocationQualifier eq.Value ty)
                     && not (isTypeSpelledOutInAsExpression eq.Value ty)
-                    && not (isTypeSpelledOutInLiteralOrInterpolatedString eq.Value))
+                    && not (isTypeSpelledOutInLiteralOrInterpolatedString eq.Value)
+                    && not (isElementTypeSpelledOutEarlierInInvocationChain eq.Value ty))
                 |> Option.defaultValue true)
             // Don't show hint if the variable's own identifier already echoes the type name
             // (`resourceCondition`/`settingChangeCondition` vs. `ResourceCondition`)

--- a/src/CSharpLanguageServer/Handlers/InlayHint.fs
+++ b/src/CSharpLanguageServer/Handlers/InlayHint.fs
@@ -281,6 +281,57 @@ module InlayHint =
                 | _ -> false
             | _ -> false
 
+        // Returns true when `initializer` is an `as` cast (`expr as SomeType`) whose target type
+        // is symbol-equal to `ty` -- in that case a `var` type hint would be purely redundant,
+        // since the type is already spelled out immediately after `as`, in the very same
+        // expression (a real example: `obj as DBBankAccount` (illustrative name), from a private
+        // codebase's `Equals` override, cited in plans/inlay-hint-reduction.md). Parenthesized
+        // expressions are unwrapped.
+        // `GetSymbolInfo` (not `GetTypeInfo`) is used on the right-hand side for the same reason
+        // as `isTypeSpelledOutInStaticInvocationQualifier` above: it's a type reference, not a
+        // value-producing expression, so it has no "value type" of its own -- its symbol *is* the
+        // type. Mirrors Roslyn's own `CSharpInlineTypeHintsService`'s `BinaryExpressionSyntax`
+        // with `AsExpression` kind candidate (see plans/inlay-hint-reduction.md).
+        let rec isTypeSpelledOutInAsExpression (initializer: ExpressionSyntax) (ty: ITypeSymbol) : bool =
+            match initializer with
+            | :? ParenthesizedExpressionSyntax as paren -> isTypeSpelledOutInAsExpression paren.Expression ty
+            | :? BinaryExpressionSyntax as binary when binary.Kind() = SyntaxKind.AsExpression ->
+                match semanticModel.GetSymbolInfo(binary.Right).Symbol |> Option.ofObj with
+                | Some(:? ITypeSymbol as castType) -> SymbolEqualityComparer.Default.Equals(castType, ty)
+                | _ -> false
+            | _ -> false
+
+        // Returns true when `initializer` is a literal expression whose kind unambiguously
+        // implies a specific type (a numeric, string, or boolean literal), or an interpolated
+        // string expression (whose natural type, absent any target typing -- which a `var`
+        // declaration never provides -- is always `string`) -- in either case a `var` type hint
+        // would be purely redundant, since the type is directly implied by the initializer's own
+        // syntax (`var x = "hi"` and `var x = $"hi {name}"` are both obviously `string`, `var x =
+        // 42` is obviously `int`, ...). Parenthesized expressions are unwrapped. Deliberately
+        // excludes the `null` literal (its type can't be inferred from the literal alone -- it
+        // could be any reference/nullable-value type) and the `default` literal (same reasoning,
+        // plus it's its own distinct syntax node, DefaultExpressionSyntax, not
+        // LiteralExpressionSyntax). Also deliberately narrow about *which* expressions count:
+        // e.g. a unary-negated numeric literal (`var x = -1`) is a PrefixUnaryExpressionSyntax,
+        // not itself a LiteralExpressionSyntax, so it's intentionally left alone by this rule.
+        // See plans/inlay-hint-reduction.md's "LiteralExpressionSyntax" Roslyn prior-art candidate
+        // and the real interpolated-string example from a private codebase's trace/log-handler
+        // class (illustrative name) that prompted extending it to interpolated strings too.
+        let rec isTypeSpelledOutInLiteralOrInterpolatedString (initializer: ExpressionSyntax) : bool =
+            match initializer with
+            | :? ParenthesizedExpressionSyntax as paren ->
+                isTypeSpelledOutInLiteralOrInterpolatedString paren.Expression
+            | :? InterpolatedStringExpressionSyntax -> true
+            | :? LiteralExpressionSyntax as literal ->
+                match literal.Kind() with
+                | SyntaxKind.NumericLiteralExpression
+                | SyntaxKind.StringLiteralExpression
+                | SyntaxKind.CharacterLiteralExpression
+                | SyntaxKind.TrueLiteralExpression
+                | SyntaxKind.FalseLiteralExpression -> true
+                | _ -> false
+            | _ -> false
+
         // Returns the significant (trivia-free) name an argument expression is "known by", so it
         // can be compared against a parameter name to detect a redundant hint:
         // - a bare identifier (`resourceName`) contributes its own text
@@ -399,15 +450,20 @@ module InlayHint =
             // type-argument list already spells out this exact type (`Enum.Parse<T>()`,
             // `JsonSerializer.Deserialize<T>()`, a local generic factory method, ...), an explicit
             // object-creation expression that already spells out this exact type (`new
-            // SomeType(...)` / `new SomeType { ... }`), or a static invocation qualified by this
-            // exact type's own name (`string.Format(...)`, `Guid.NewGuid()`, ...)
+            // SomeType(...)` / `new SomeType { ... }`), a static invocation qualified by this
+            // exact type's own name (`string.Format(...)`, `Guid.NewGuid()`, ...), an `as` cast to
+            // this exact type (`obj as SomeType`), or a literal/interpolated-string expression
+            // whose type is directly implied by its own syntax (`"hi"`, `42`, `true`, `$"hi
+            // {name}"`, ...)
             |> Option.filter (fun ty ->
                 var.Variables[0].Initializer
                 |> Option.ofObj
                 |> Option.map (fun eq ->
                     not (isTypeSpelledOutInGenericInvocation eq.Value ty)
                     && not (isTypeSpelledOutInObjectCreation eq.Value ty)
-                    && not (isTypeSpelledOutInStaticInvocationQualifier eq.Value ty))
+                    && not (isTypeSpelledOutInStaticInvocationQualifier eq.Value ty)
+                    && not (isTypeSpelledOutInAsExpression eq.Value ty)
+                    && not (isTypeSpelledOutInLiteralOrInterpolatedString eq.Value))
                 |> Option.defaultValue true)
             // Don't show hint if the variable's own identifier already echoes the type name
             // (`resourceCondition`/`settingChangeCondition` vs. `ResourceCondition`)

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -586,4 +586,34 @@ namespace Project.InlayHintTest
             var result = await CreateAsync<Widget>();
         }
     }
+
+    // Long, compound type hints (anonymous types, tuples) grow without bound with the number of
+    // members/elements and can dwarf a line of real code -- see plans/inlay-hint-reduction.md's
+    // "anonymous/tuple-type verbosity" follow-up. Middle-truncated with the full name moved to the
+    // hint's hover tooltip, rather than shown/lost in full.
+    public class LongTypeNameHelper
+    {
+        public string ShortName { get; set; } = "";
+    }
+
+    public class LongTypeNameSubject
+    {
+        public void ShortTypeHintIsNotTruncated()
+        {
+            var helper = new LongTypeNameHelper();
+            var name = helper.ShortName;
+        }
+
+        public void LongAnonymousTypeHintIsTruncated()
+        {
+            var summary = new
+            {
+                AlphaValue = 1,
+                BravoValue = 2,
+                CharlieValue = 3,
+                DeltaValue = 4,
+                EchoValue = 5
+            };
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -467,4 +467,45 @@ namespace Project.InlayHintTest
             chained.Where(p => p != null);
         }
     }
+
+    public class LiteralInitializerSubject
+    {
+        public void StringLiteralTypeHintIsSuppressed()
+        {
+            var greeting = "hi";
+        }
+
+        public void NumericLiteralTypeHintIsSuppressed()
+        {
+            var count = 42;
+        }
+
+        public void BooleanLiteralTypeHintIsSuppressed()
+        {
+            var flag = true;
+        }
+
+        public void UnaryMinusExpressionKeepsHint()
+        {
+            var negated = -1;
+        }
+
+        // Mirrors a real `var logMessage = $"{level}: {message}";`-shaped example (illustrative
+        // names) from a private codebase's trace/log-handler class, cited in
+        // plans/inlay-hint-reduction.md: an interpolated string's natural type is always `string`
+        // (there's no target type to widen it to `FormattableString`/`IFormattable` in a `var`
+        // declaration), so the hint is exactly as redundant as a plain string literal's.
+        public void InterpolatedStringTypeHintIsSuppressed(string name)
+        {
+            var greeting = $"Hello, {name}";
+        }
+    }
+
+    public class AsExpressionInitializerSubject
+    {
+        public void AsExpressionTypeHintIsSuppressed(object obj)
+        {
+            var widget = obj as Widget;
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -533,6 +533,14 @@ namespace Project.InlayHintTest
         {
             return new System.Collections.Generic.List<T>();
         }
+
+        // Mirrors the real `await db.Query<T>().Where(...).ToListAsync();` shape (illustrative
+        // names) cited in plans/inlay-hint-reduction.md -- the `await`-wrapped sibling of the
+        // synchronous `ToList()` above.
+        public System.Threading.Tasks.Task<System.Collections.Generic.List<T>> ToListAsync()
+        {
+            return System.Threading.Tasks.Task.FromResult(new System.Collections.Generic.List<T>());
+        }
     }
 
     public class ListRepositoryQuerySubject
@@ -548,6 +556,11 @@ namespace Project.InlayHintTest
         {
             var partial = repository.Query<Widget>().Where(p => p != null);
             var widgets2 = partial.ToList();
+        }
+
+        public async System.Threading.Tasks.Task ElementTypeSpelledOutEarlierInAwaitedChainTypeHintIsSuppressed()
+        {
+            var widgets = await repository.Query<Widget>().Where(p => p != null).ToListAsync();
         }
     }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -508,4 +508,46 @@ namespace Project.InlayHintTest
             var widget = obj as Widget;
         }
     }
+
+    // Mirrors the real-world `var orders = await db.Query<DBOrder>().Where(o => ...).ToListAsync();`
+    // idiom cited in plans/inlay-hint-reduction.md (illustrative names): the *element* type of the
+    // inferred `List<T>` was already spelled out earlier in the same fluent chain, at the
+    // `Query<T>()` call -- `ToList`/`ToListAsync`-style materialization doesn't introduce any new
+    // type information beyond what's already visible a few calls to the left.
+    public class ListRepository
+    {
+        public ListRepository<T> Query<T>()
+        {
+            return new ListRepository<T>();
+        }
+    }
+
+    public class ListRepository<T>
+    {
+        public ListRepository<T> Where(System.Func<T, bool> predicate)
+        {
+            return this;
+        }
+
+        public System.Collections.Generic.List<T> ToList()
+        {
+            return new System.Collections.Generic.List<T>();
+        }
+    }
+
+    public class ListRepositoryQuerySubject
+    {
+        private readonly ListRepository repository = new ListRepository();
+
+        public void ElementTypeSpelledOutEarlierInChainTypeHintIsSuppressed()
+        {
+            var widgets = repository.Query<Widget>().Where(p => p != null).ToList();
+        }
+
+        public void ElementTypeNotSpelledOutInChainKeepsHint()
+        {
+            var partial = repository.Query<Widget>().Where(p => p != null);
+            var widgets2 = partial.ToList();
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -563,4 +563,27 @@ namespace Project.InlayHintTest
             var widgets = await repository.Query<Widget>().Where(p => p != null).ToListAsync();
         }
     }
+
+    // Mirrors the real `var order = await db.GetAsync<DBOrder>(orderConfirmed.OrderId);` idiom
+    // (illustrative entity name) cited in plans/inlay-hint-reduction.md: unlike
+    // `ListRepositoryQuerySubject` above (whose element type is spelled out earlier in a *chain*),
+    // here the generic invocation whose type argument is spelled out IS the initializer's own,
+    // single, outermost invocation -- rule #5's exact original shape
+    // (`isTypeSpelledOutInGenericInvocation`) -- just wrapped in `await`, same as almost every
+    // real-world NHibernate `...Async<T>()` call site.
+    public class AwaitedGenericInvocationSubject
+    {
+        private static System.Threading.Tasks.Task<T> CreateAsync<T>() where T : new()
+        {
+            return System.Threading.Tasks.Task.FromResult(new T());
+        }
+
+        public async System.Threading.Tasks.Task AwaitedGenericInvocationSpellingOutTypeIsSuppressed()
+        {
+            // Deliberately not named `widget`/`createdWidget`/etc. -- that would also be
+            // suppressed by the unrelated identifier-echoes-type-name rule (#6), masking whether
+            // this test is actually exercising the await-unwrapping fix for rule #5.
+            var result = await CreateAsync<Widget>();
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/InlayHintTest.cs
@@ -432,4 +432,39 @@ namespace Project.InlayHintTest
             helper.Insert(0, 5);
         }
     }
+
+    // Mirrors a common ORM/data-access idiom (`db.Query<T>().Where(p => ...)`): the lambda's
+    // implicit parameter type is already spelled out one call earlier, in the receiver's own
+    // explicit generic type argument.
+    public class Repository
+    {
+        public Repository<T> Query<T>()
+        {
+            return new Repository<T>();
+        }
+    }
+
+    public class Repository<T>
+    {
+        public Repository<T> Where(System.Func<T, bool> predicate)
+        {
+            return this;
+        }
+    }
+
+    public class RepositoryQuerySubject
+    {
+        private readonly Repository repository = new Repository();
+
+        public void LambdaParameterTypeSpelledOutInReceiverIsSuppressed()
+        {
+            repository.Query<Widget>().Where(p => p != null);
+        }
+
+        public void LambdaParameterTypeNotSpelledOutInReceiverKeepsHint()
+        {
+            var chained = repository.Query<Widget>().Where(p => p != null);
+            chained.Where(p => p != null);
+        }
+    }
 }

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -960,3 +960,40 @@ let ``textDocument/inlayHint suppresses a var type hint when an "as" expression'
         hints |> hintsOnLine 506u |> hasHintWithLabel ": Widget",
         "Expected no \": Widget\" hint on line 506 (type is already spelled out right after `as`)"
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when the element type was spelled out earlier in a fluent chain``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 543 (0-indexed): `var widgets = repository.Query<Widget>().Where(p => p != null).ToList();`
+    // -- mirrors the real `var orders = await db.Query<DBOrder>().Where(o => ...).ToListAsync();`
+    // idiom cited in plans/inlay-hint-reduction.md: `Widget` is already spelled out earlier in the
+    // same chain, at `Query<Widget>()`, so the `: List<Widget>` hint on the materialized result is
+    // redundant.
+    Assert.IsFalse(
+        hints |> hintsOnLine 543u |> hasHintWithLabel ": List<Widget>",
+        "Expected no \": List<Widget>\" hint on line 543 (element type is already spelled out\
+         earlier in the fluent chain, at Query<Widget>())"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a var type hint when the element type isn't spelled out in the same chain`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 549 (0-indexed): `var widgets2 = partial.ToList();`
+    // -- the explicit `Query<Widget>()` generic invocation happened in a *previous* statement, not
+    // in this initializer's own invocation chain, so the type isn't "spelled out" from this hint's
+    // point of view and the hint should be kept.
+    Assert.IsTrue(
+        hints |> hintsOnLine 549u |> hasHintWithLabel ": List<Widget>",
+        "Expected a \": List<Widget>\" hint on line 549 (element type isn't spelled out anywhere\
+         in this initializer's own invocation chain)"
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -32,6 +32,11 @@ let private hintsOnLine (line: uint32) (hints: InlayHint array) : InlayHint arra
 let private hasHintWithLabel (label: string) (hints: InlayHint array) : bool =
     hints |> Array.exists (fun h -> labelText h = label)
 
+let private tooltipText (hint: InlayHint) : string option =
+    match hint.Tooltip with
+    | Some(U2.C1 s) -> Some s
+    | _ -> None
+
 [<Test>]
 let ``textDocument/inlayHint shows a type hint for a var declaration initialized from a method call`` () =
     use client = activateFixture "genericProject"
@@ -1043,4 +1048,62 @@ let ``textDocument/inlayHint suppresses a var type hint when an awaited generic 
         hints |> hintsOnLine 585u |> hasHintWithLabel ": Widget",
         "Expected no \": Widget\" hint on line 585 (type is already spelled out in the awaited\
          invocation's explicit type argument)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint does not truncate a short type hint's label or add a tooltip`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 603 (0-indexed): `var name = helper.ShortName;` -- infers `string`, well under the
+    // truncation threshold.
+    let onLine = hints |> hintsOnLine 603u
+    let typeHint = onLine |> Array.tryFind (fun h -> labelText h = ": string")
+
+    Assert.IsTrue(typeHint.IsSome, sprintf "Expected a \": string\" hint on line 603, got: %A" onLine)
+
+    Assert.IsTrue(
+        typeHint |> Option.bind tooltipText |> Option.isNone,
+        "Expected no tooltip on an untruncated, short type hint"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint middle-truncates a long anonymous-type hint and moves the full name to its tooltip`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 608 (0-indexed): `var summary = new { AlphaValue = ..., BravoValue = ..., ... };` --
+    // the anonymous type's rendered name (`<anonymous type: int AlphaValue, int BravoValue, ...>`)
+    // is far longer than the truncation threshold.
+    let onLine = hints |> hintsOnLine 608u
+    let typeHint = onLine |> Array.tryFind (fun h -> (labelText h).StartsWith(": "))
+
+    Assert.IsTrue(typeHint.IsSome, sprintf "Expected a type hint on line 608, got: %A" onLine)
+
+    let label = typeHint |> Option.map labelText |> Option.defaultValue ""
+
+    Assert.IsTrue(label.Contains("..."), sprintf "Expected the truncated label to contain an ellipsis, got: %s" label)
+
+    // 2 for the ": " prefix, plus the truncation threshold itself.
+    Assert.IsTrue(
+        label.Length <= 2 + 40,
+        sprintf "Expected the truncated label to be short, got (%d chars): %s" label.Length label
+    )
+
+    let tooltip = typeHint |> Option.bind tooltipText
+
+    Assert.IsTrue(tooltip.IsSome, "Expected a tooltip carrying the full, untruncated type name")
+
+    Assert.IsTrue(
+        (tooltip |> Option.defaultValue "").Length > label.Length,
+        "Expected the tooltip's full type name to be longer than the truncated label"
+    )
+
+    Assert.IsFalse(
+        (tooltip |> Option.defaultValue "").Contains("..."),
+        "Expected the tooltip to hold the full, untruncated type name, not another truncated copy"
     )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -881,3 +881,82 @@ let ``textDocument/inlayHint never shows a type hint for an implicit lambda para
         hints |> hintsOnLine 466u |> hasHintWithLabel ": Widget",
         "Expected no \": Widget\" implicit lambda-parameter type hint on line 466"
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint for a string literal initializer`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 474 (0-indexed): `var greeting = "hi";`
+    Assert.IsFalse(
+        hints |> hintsOnLine 474u |> hasHintWithLabel ": string",
+        "Expected no \": string\" hint on line 474 (type is directly implied by the string literal)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint for a numeric literal initializer`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 479 (0-indexed): `var count = 42;`
+    Assert.IsFalse(
+        hints |> hintsOnLine 479u |> hasHintWithLabel ": int",
+        "Expected no \": int\" hint on line 479 (type is directly implied by the numeric literal)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint for a boolean literal initializer`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 484 (0-indexed): `var flag = true;`
+    Assert.IsFalse(
+        hints |> hintsOnLine 484u |> hasHintWithLabel ": bool",
+        "Expected no \": bool\" hint on line 484 (type is directly implied by the boolean literal)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint keeps a var type hint for a unary-negated numeric expression`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 489 (0-indexed): `var negated = -1;` -- a PrefixUnaryExpressionSyntax, not itself a
+    // LiteralExpressionSyntax, so intentionally out of scope for the literal-initializer rule
+    Assert.IsTrue(
+        hints |> hintsOnLine 489u |> hasHintWithLabel ": int",
+        "Expected a \": int\" hint on line 489 (initializer is a unary expression, not a bare literal)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint for an interpolated string initializer`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 498 (0-indexed): `var greeting = $"Hello, {name}";`
+    Assert.IsFalse(
+        hints |> hintsOnLine 498u |> hasHintWithLabel ": string",
+        "Expected no \": string\" hint on line 498 (interpolated string's natural type is always string)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when an "as" expression's target type matches`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 506 (0-indexed): `var widget = obj as Widget;`
+    Assert.IsFalse(
+        hints |> hintsOnLine 506u |> hasHintWithLabel ": Widget",
+        "Expected no \": Widget\" hint on line 506 (type is already spelled out right after `as`)"
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -1020,3 +1020,27 @@ let ``textDocument/inlayHint suppresses a var type hint when the element type wa
         "Expected no \": List<Widget>\" hint on line 562 (element type is already spelled out\
          earlier in the fluent chain, at Query<Widget>(), even though the chain is awaited)"
     )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when an awaited generic invocation's type argument matches``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 585 (0-indexed): `var result = await CreateAsync<Widget>();`
+    // -- mirrors the real, `await`-wrapped shape from a further follow-up spot-check cited in
+    // plans/inlay-hint-reduction.md: `var order = await db.GetAsync<DBOrder>(...);` (illustrative
+    // entity name). Unlike the previous test, this is rule #5's *original* shape
+    // (`isTypeSpelledOutInGenericInvocation`) -- the generic invocation whose type argument
+    // matches is the initializer's own single, outermost invocation, not an earlier call in a
+    // chain -- which, before this fix, didn't unwrap `await` either. The variable is deliberately
+    // named `result` (not `widget`) so this test isn't accidentally passing for the unrelated
+    // identifier-echoes-type-name reason (rule #6).
+    Assert.IsFalse(
+        hints |> hintsOnLine 585u |> hasHintWithLabel ": Widget",
+        "Expected no \": Widget\" hint on line 585 (type is already spelled out in the awaited\
+         invocation's explicit type argument)"
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -847,3 +847,37 @@ let ``textDocument/inlayHint keeps an "item" parameter hint when the call has mo
              still helps disambiguate from \"index\"), got: %A"
             onLine
     )
+
+[<Test>]
+let ``textDocument/inlayHint never shows a type hint for an implicit lambda parameter`` () =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // Implicit lambda-parameter type hints (the `(p: SomeType) => ...` style hint) were removed
+    // entirely -- see plans/inlay-hint-reduction.md. Real-world evidence showed this category is
+    // almost always redundant (spelled out by an immediately-preceding generic invocation,
+    // inferable from a property access one hop away, or simply repeated for the same type across
+    // multiple lambdas in one short fluent chain), and Visual Studio's own default configuration
+    // ships with all inline hints off by default.
+
+    // line 144 (0-indexed): `new FluentQuery().Where(x => x > 0);` -- `x` infers to `int`
+    Assert.IsFalse(
+        hints |> hintsOnLine 144u |> hasHintWithLabel ": int",
+        "Expected no \": int\" implicit lambda-parameter type hint on line 144"
+    )
+
+    // line 460 (0-indexed): `repository.Query<Widget>().Where(p => p != null);` -- `p` infers to
+    // `Widget`, spelled out one call earlier at `Query<Widget>`
+    Assert.IsFalse(
+        hints |> hintsOnLine 460u |> hasHintWithLabel ": Widget",
+        "Expected no \": Widget\" implicit lambda-parameter type hint on line 460"
+    )
+
+    // line 466 (0-indexed): `chained.Where(p => p != null);` -- `p` also infers to `Widget`, but
+    // here the receiver isn't itself a generic invocation that spells the type out
+    Assert.IsFalse(
+        hints |> hintsOnLine 466u |> hasHintWithLabel ": Widget",
+        "Expected no \": Widget\" implicit lambda-parameter type hint on line 466"
+    )

--- a/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InlayHintTests.fs
@@ -970,14 +970,14 @@ let ``textDocument/inlayHint suppresses a var type hint when the element type wa
 
     let hints = getHints client doc
 
-    // line 543 (0-indexed): `var widgets = repository.Query<Widget>().Where(p => p != null).ToList();`
-    // -- mirrors the real `var orders = await db.Query<DBOrder>().Where(o => ...).ToListAsync();`
+    // line 551 (0-indexed): `var widgets = repository.Query<Widget>().Where(p => p != null).ToList();`
+    // -- mirrors the real `var orders = await db.Query<DBSalesOrder>().Where(o => ...).ToListAsync();`
     // idiom cited in plans/inlay-hint-reduction.md: `Widget` is already spelled out earlier in the
     // same chain, at `Query<Widget>()`, so the `: List<Widget>` hint on the materialized result is
     // redundant.
     Assert.IsFalse(
-        hints |> hintsOnLine 543u |> hasHintWithLabel ": List<Widget>",
-        "Expected no \": List<Widget>\" hint on line 543 (element type is already spelled out\
+        hints |> hintsOnLine 551u |> hasHintWithLabel ": List<Widget>",
+        "Expected no \": List<Widget>\" hint on line 551 (element type is already spelled out\
          earlier in the fluent chain, at Query<Widget>())"
     )
 
@@ -988,12 +988,35 @@ let ``textDocument/inlayHint keeps a var type hint when the element type isn't s
 
     let hints = getHints client doc
 
-    // line 549 (0-indexed): `var widgets2 = partial.ToList();`
+    // line 557 (0-indexed): `var widgets2 = partial.ToList();`
     // -- the explicit `Query<Widget>()` generic invocation happened in a *previous* statement, not
     // in this initializer's own invocation chain, so the type isn't "spelled out" from this hint's
     // point of view and the hint should be kept.
     Assert.IsTrue(
-        hints |> hintsOnLine 549u |> hasHintWithLabel ": List<Widget>",
-        "Expected a \": List<Widget>\" hint on line 549 (element type isn't spelled out anywhere\
+        hints |> hintsOnLine 557u |> hasHintWithLabel ": List<Widget>",
+        "Expected a \": List<Widget>\" hint on line 557 (element type isn't spelled out anywhere\
          in this initializer's own invocation chain)"
+    )
+
+[<Test>]
+let ``textDocument/inlayHint suppresses a var type hint when the element type was spelled out earlier in an awaited fluent chain``
+    ()
+    =
+    use client = activateFixture "genericProject"
+    use doc = client.Open "Project/InlayHintTest.cs"
+
+    let hints = getHints client doc
+
+    // line 562 (0-indexed):
+    // `var widgets = await repository.Query<Widget>().Where(p => p != null).ToListAsync();`
+    // -- mirrors the real, `await`-wrapped shape from a follow-up spot-check cited in
+    // plans/inlay-hint-reduction.md (a second handler file in the same private codebase):
+    // `var masterOffices = await db.Query<DBOffice>().Where(...).FetchMany(...).ToListAsync();`.
+    // The synchronous version of this rule (tested above) doesn't unwrap an `AwaitExpressionSyntax`
+    // wrapping the whole invocation chain, so it missed this -- extremely common, since virtually
+    // every real NHibernate `...Async()` call site is awaited -- shape.
+    Assert.IsFalse(
+        hints |> hintsOnLine 562u |> hasHintWithLabel ": List<Widget>",
+        "Expected no \": List<Widget>\" hint on line 562 (element type is already spelled out\
+         earlier in the fluent chain, at Query<Widget>(), even though the chain is awaited)"
     )


### PR DESCRIPTION
Follow-up to #375: two more `textDocument/inlayHint` noise-reduction changes in `Handlers/InlayHint.fs`.

- **Removes implicit lambda-parameter type hints entirely** (the `(p: SomeType) => ...` hint). A narrower, fluent-chain-based suppression rule was tried first, but further real-world samples kept surfacing more redundant shapes it wasn't scoped to catch (e.g. the same type re-hinted across chained lambdas, or trivially inferable from an adjacent property name). Since every real occurrence turned out redundant, and VS Code's own default ships all inline hints — including this one — off entirely, we now drop the whole category instead of chasing more narrow rules.
- **Suppresses redundant `var` type hints** when the type is already spelled out in the initializer itself: `as`-cast expressions (`var x = obj as Widget;`) and literal/interpolated-string initializers (`var x = "hi";`, `var x = $"hi {name}";`).

Covered by regression/positive/negative-control tests in `InlayHintTests.fs`. See `plans/inlay-hint-reduction.md` for the full research/design writeup and real-world evidence behind each rule.