### PR TITLE
Don't force a global TargetFramework when single-target projects disagree

### DIFF
--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -207,11 +207,25 @@ let workspaceTargetFramework (tfmsPerProject: Map<string, string list>) : option
     match tfmsPerProject.Count with
     | 0 -> None
     | _ ->
-        tfmsPerProject.Values
-        |> Seq.map Set.ofSeq
-        |> List.ofSeq
-        |> compatibleTfmSet
-        |> bestTfm
+        let projectTfmSets = tfmsPerProject.Values |> Seq.map Set.ofSeq |> List.ofSeq
+
+        let allProjectsAreSingleTarget =
+            projectTfmSets |> List.forall (fun tfms -> Set.count tfms = 1)
+
+        let projectTfmSetsAreHeterogeneous = (projectTfmSets |> Set.ofList |> Set.count) > 1
+
+        if allProjectsAreSingleTarget && projectTfmSetsAreHeterogeneous then
+            // A global TargetFramework override is only needed to disambiguate
+            // multi-targeted projects. When all projects are single-targeted but
+            // don't agree on one TFM, any global override breaks the design-time
+            // build of every project that does not declare the chosen TFM
+            // (NETSDK1005, all references lost) -- e.g. a single net9.0-windows
+            // project would otherwise force net9.0-windows onto every net9.0
+            // project in the solution. With no override each project builds
+            // with its own declared TFM instead.
+            None
+        else
+            projectTfmSets |> compatibleTfmSet |> bestTfm
 
 let resolveDefaultWorkspaceProps (targetFramework: string option) : Map<string, string> =
     let applyTargetFrameworkProp props =

--- a/tests/CSharpLanguageServer.Tests/InternalTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InternalTests.fs
@@ -18,8 +18,11 @@ open CSharpLanguageServer.Roslyn.Solution
 [<TestCase("1.csproj:net8.0,net10.0 2.csproj:netstandard2.0,net462", "net10.0")>]
 [<TestCase("1.csproj:net8.0,net10.0 2.csproj:net8.0,net10.0", "net10.0")>]
 [<TestCase("1.csproj:net8.0 2.csproj:net8.0,net10.0", "net10.0")>]
-[<TestCase("1.csproj:net8.0 2.csproj:net9.0-windows", "net9.0-windows")>]
-[<TestCase("1.csproj:net9.0 2.csproj:net9.0-windows", "net9.0-windows")>]
+[<TestCase("1.csproj:net8.0 2.csproj:net9.0-windows", null)>]
+[<TestCase("1.csproj:net9.0 2.csproj:net9.0-windows", null)>]
+[<TestCase("1.csproj:net8.0 2.csproj:net9.0", null)>]
+[<TestCase("1.csproj:net9.0 2.csproj:net9.0 3.csproj:net9.0-windows", null)>]
+[<TestCase("1.csproj:net9.0,net9.0-windows 2.csproj:net9.0", "net9.0-windows")>]
 let testApplyWorkspaceTargetFrameworkProp (tfmList: string, expectedTfm: string | null) =
 
     let parseTfmList (projectEntry: string) : string * list<string> =


### PR DESCRIPTION
`workspaceTargetFramework` picks a single TFM for the whole workspace and applies it as a global `TargetFramework` property. `bestTfm` prefers platform-specific TFMs, so a single net9.0-windows project in an otherwise net9.0 solution forces `TargetFramework=net9.0-windows` onto every project.

For a single-targeted project this override changes the TFM it is built as, while NuGet restore only ran for the TFM it declares. The design-time build then fails with NETSDK1005 ("Assets file doesn't have a target for 'net9.0-windows'"), the project loads without any references, and every file in it reports CS0234/CS0246 on all usings. In a 100-project solution with one WPF tool this broke reference resolution for the 99 other projects ("Found project reference without a matching metadata reference" for every project reference).

The global override only exists to disambiguate multi-targeted projects. This change skips it when all projects are single-targeted but declare different TFMs: nothing needs disambiguation in that case, and each project design-time-builds correctly with its own declared TFM - including the platform-specific one.

Behavior is unchanged when any multi-targeted project is present, or when all projects agree on one TFM.

Two test expectations in `testApplyWorkspaceTargetFrameworkProp` encoded the old behavior (`net9.0 + net9.0-windows --> net9.0-windows`) and were updated to expect no override; three cases were added to cover the new rule.

PS: I'm using Linux, there's no `net9.0-windows`
