### PR TITLE
Add a Nix flake

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
@@ -32,7 +32,7 @@ jobs:
         working-directory: src/CSharpLanguageServer
 
       - name: Upload NuGet packages as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: packages
           path: src/CSharpLanguageServer/release/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ matrix.dotnet }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,27 @@
 dotnet build
 ```
 
+## Nix development environment
+
+Enter the reproducible development shell with:
+
+```
+nix develop
+```
+
+The regular `dotnet build` workflow does not require a Nix build. Build the Nix package when
+you need to verify or produce the packaged application:
+
+```
+nix build .#csharp-ls
+```
+
+After changing NuGet dependencies, update the Nix dependency lock with:
+
+```
+nix run .#update-deps
+```
+
 ## Run tests
 
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,152 @@
+{
+  description = "csharp-ls development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      ...
+    }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+      dotnetSdkAttribute =
+        let
+          sdkVersion = (builtins.fromJSON (builtins.readFile ./global.json)).sdk.version;
+          versionParts = nixpkgs.lib.splitString "." sdkVersion;
+          featureBand = builtins.substring 0 1 (builtins.elemAt versionParts 2);
+        in
+        "sdk_${builtins.elemAt versionParts 0}_${builtins.elemAt versionParts 1}_${featureBand}xx";
+
+      mkDotnetSdk =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.dotnetCorePackages.${dotnetSdkAttribute};
+
+      mkUpdateDeps =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        pkgs.writeShellApplication {
+          name = "csharp-ls-update-deps";
+          runtimeInputs = [
+            pkgs.git
+            pkgs.nix
+          ];
+          text = ''
+            set -euo pipefail
+
+            repo_root=$(git rev-parse --show-toplevel)
+            cd "$repo_root"
+            fetch_deps=$(nix build --no-link --no-write-lock-file --print-out-paths \
+              path:.#csharp-ls.passthru.fetch-deps)
+            "$fetch_deps" nix/deps.json
+          '';
+        };
+
+      mkCsharpLs =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          inherit (pkgs) lib;
+          sdk = mkDotnetSdk system;
+        in
+        pkgs.buildDotnetModule {
+          __structuredAttrs = true;
+          pname = "csharp-ls";
+          version = "0.26.0";
+
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./CHANGELOG.md
+              ./Directory.Build.props
+              ./Directory.Build.targets
+              ./Directory.Packages.props
+              ./README.md
+              ./global.json
+              ./nuget.config
+              ./src/CSharpLanguageServer
+              ./src/Ionide.LanguageServerProtocol
+            ];
+          };
+
+          projectFile = "src/CSharpLanguageServer/CSharpLanguageServer.fsproj";
+          nugetDeps = ./nix/deps.json;
+          dotnet-sdk = sdk;
+          dotnet-runtime = sdk;
+          executables = [ "CSharpLanguageServer" ];
+
+          postFixup = ''
+            ln -s CSharpLanguageServer "$out/bin/csharp-ls"
+          '';
+
+          meta = {
+            description = "C# LSP language server";
+            homepage = "https://github.com/razzmatazz/csharp-language-server";
+            license = lib.licenses.mit;
+            mainProgram = "csharp-ls";
+            platforms = systems;
+          };
+        };
+    in
+    {
+      packages = forAllSystems (system: {
+        default = mkCsharpLs system;
+        csharp-ls = self.packages.${system}.default;
+      });
+
+      apps = forAllSystems (system: {
+        default = self.apps.${system}.csharp-ls;
+        csharp-ls = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/csharp-ls";
+          meta = self.packages.${system}.default.meta;
+        };
+        update-deps = {
+          type = "app";
+          program = "${mkUpdateDeps system}/bin/csharp-ls-update-deps";
+          meta.description = "Update the Nix NuGet dependency lock";
+        };
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShellNoCC {
+            packages = [
+              (mkDotnetSdk system)
+              pkgs.fantomas
+              pkgs.git
+              pkgs.nixfmt
+            ];
+
+            DOTNET_CLI_TELEMETRY_OPTOUT = "1";
+            DOTNET_NOLOGO = "1";
+            NUGET_XMLDOC_MODE = "skip";
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: (import nixpkgs { inherit system; }).nixfmt);
+
+      checks = forAllSystems (system: {
+        package = self.packages.${system}.default;
+      });
+    };
+}

--- a/nix/deps.json
+++ b/nix/deps.json
@@ -1,0 +1,532 @@
+[
+  {
+    "pname": "Argu",
+    "version": "6.2.5",
+    "hash": "sha256-5HcZcvco4e8+hgLhzlxk7ZmFVLtZL9LVr7LbmXsLmNU="
+  },
+  {
+    "pname": "Castle.Core",
+    "version": "5.2.1",
+    "hash": "sha256-uNe//PCnYGLhxxQpLDyTQuoIH5u7dGDlyjc2wqAQ4D4="
+  },
+  {
+    "pname": "DotNet.ReproducibleBuilds",
+    "version": "1.2.25",
+    "hash": "sha256-Vl9RPq9vCO4bjulPZiOr3gDVKlr9vnuKIIX3KWlRxvw="
+  },
+  {
+    "pname": "FSharp.Control.AsyncSeq",
+    "version": "3.2.1",
+    "hash": "sha256-ezSZrGMqTQZKt0ojCRKUWuDGx1JVUyNZzkmUZjVqiAk="
+  },
+  {
+    "pname": "FSharp.Core",
+    "version": "10.0.101",
+    "hash": "sha256-i7crdE0/u+/mFCD1rNFc/iT5TFr8Dae9dNpVRmbpSbY="
+  },
+  {
+    "pname": "Humanizer.Core",
+    "version": "2.14.1",
+    "hash": "sha256-EXvojddPu+9JKgOG9NSQgUTfWq1RpOYw7adxDPKDJ6o="
+  },
+  {
+    "pname": "ICSharpCode.Decompiler",
+    "version": "9.1.0.7988",
+    "hash": "sha256-zPLgLNO4cCrtN9BR9x6X+W0MNkQ71nADIopOC1VBhAQ="
+  },
+  {
+    "pname": "Ionide.KeepAChangelog.Tasks",
+    "version": "0.1.8",
+    "hash": "sha256-yyg8Az7VG4rK/AsMC9cUZc67onl6wOGXoUqHm4Wi3xg="
+  },
+  {
+    "pname": "MessagePack",
+    "version": "2.5.108",
+    "hash": "sha256-+vMXyEbfutY5WOFuFnNF24uLcKJTTdntVrVlSJH4yjI="
+  },
+  {
+    "pname": "MessagePack.Annotations",
+    "version": "2.5.108",
+    "hash": "sha256-u3Qu8UftNIz3oIzQUMa7Z0G6VzmDLcAnAeNQ3lB3YVk="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "10.0.1",
+    "hash": "sha256-aHoslRGmAot/z1GCCqSzjAxT/hltxOOIZ1/oti4WbGY="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "10.0.8",
+    "hash": "sha256-x8HC64abrN9BmlnYBswEzHClDEWcHAnskeaMX9N8/QQ="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "5.0.0",
+    "hash": "sha256-bpJjcJSUSZH0GeOXoZI12xUQOf2SRtxG7sZV0dWS5TI="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "6.0.0",
+    "hash": "sha256-49+H/iFwp+AfCICvWcqo9us4CzxApPKC37Q5Eqrw+JU="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "7.0.0",
+    "hash": "sha256-1e031E26iraIqun84ad0fCIR4MJZ1hcQo4yFN+B7UfE="
+  },
+  {
+    "pname": "Microsoft.Build",
+    "version": "18.7.1",
+    "hash": "sha256-SuiMJA9ZSVRMgWCSuqmI+utYuccmObKGcXr6c2zvPDg="
+  },
+  {
+    "pname": "Microsoft.Build.Framework",
+    "version": "18.7.1",
+    "hash": "sha256-reiTfnhkYsgfMBlcyGpDICzVtmJaAt0iOjiq9vg9owg="
+  },
+  {
+    "pname": "Microsoft.Build.Locator",
+    "version": "1.10.12",
+    "hash": "sha256-bBaWXc7XD11xlr2bY50A7QHY+NVpQXySlThR7scjQDA="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis",
+    "version": "5.6.0",
+    "hash": "sha256-KhxRCZ/CwPdt8JSlLnEiyTy8YSp82BRoxqd+C9Bbves="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Analyzers",
+    "version": "5.3.0",
+    "hash": "sha256-eUjU7MDekcbDQxUButcWK7siHx6HmrgdDMLnpGYRVLM="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Common",
+    "version": "5.6.0",
+    "hash": "sha256-Q+34cKCUHLMUdigLSuCunqcpAzagynq7O6LJ09EPu6g="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp",
+    "version": "5.6.0",
+    "hash": "sha256-nrzGZk9oLuCEvhDT+IS+XBVOuHVrwL8RGj0rZFP4SRo="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp.Features",
+    "version": "5.6.0",
+    "hash": "sha256-YC8OGPt1A9lv4eupthHNpupuN9+CcchBzOTItp1uTfo="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp.Workspaces",
+    "version": "5.6.0",
+    "hash": "sha256-4N+AQwgGfxVh5O45UE8fMOlI7n+oW8rjSnk4Z2XNuuw="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Elfie",
+    "version": "1.0.0",
+    "hash": "sha256-E/+PlegvWZ59e5Ti3TvKJBLa3qCnDKmi7+DcnOo1ufg="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Features",
+    "version": "5.6.0",
+    "hash": "sha256-Yeqsrqbqk876uCOVQ5pyd6M4qL/w9qyGeDyFFwLlF8M="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Scripting.Common",
+    "version": "5.6.0",
+    "hash": "sha256-qbH8tUlbfRcaRD5xIPBfRHannv/9vibd/6VaRqhAaGw="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.VisualBasic",
+    "version": "5.6.0",
+    "hash": "sha256-Ta/F0x4O2LKGvTDJJ5KdxPiPCgkojYyn5KGTC0rp2Dk="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
+    "version": "5.6.0",
+    "hash": "sha256-kzVrGMOByHp6SW4bgfXHWHN8+7PepRanWHFims5A/qk="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Workspaces.Common",
+    "version": "5.6.0",
+    "hash": "sha256-Kxxsk4a0wO3L85E48we9YUMtIWzdf4d2g/c3u6SBcqE="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Workspaces.MSBuild",
+    "version": "5.6.0",
+    "hash": "sha256-sAoU+7tUGPCLIVQP07KBOeanXWL3N2cDRQCbZlVA6u4="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Workspaces.MSBuild.Contracts",
+    "version": "5.6.0",
+    "hash": "sha256-a5bmdS56Ahra4LrVbOEuzpQjjGmww7cB44h1byWBjbQ="
+  },
+  {
+    "pname": "Microsoft.DiaSymReader",
+    "version": "2.0.0",
+    "hash": "sha256-8hotZmh8Rb6Q6oD9Meb74SvAdbDo39Y/1m8h43HHjjw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-vUxhCZIXgIYPjNLWRQJBNTfPGn5K4IfoFfoOcq1hoUU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "10.0.9",
+    "hash": "sha256-CtlL43WsblxUX4JY57DROPlp8tkbG50npcodGVQL9ho="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "10.0.9",
+    "hash": "sha256-4d8r6Vyune1Qb0kwqzfGPA7BK2nvaiOenTiJedzq6sU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-pliaksEAQdxyPURUVSlXpfF3LzJB93zHaeEDsaF5QJE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "10.0.9",
+    "hash": "sha256-ouJa+84H/bfMi67v25hjEWhTIyBHaWTJAoEvArwbrGA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "10.0.1",
+    "hash": "sha256-RKOB+zPrtQNUbJY/1jR54rKOM8KHPgynPExxugku3I8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "10.0.9",
+    "hash": "sha256-YIqgDknwTq48X88Imdrfav3tmQ6tZwIOYsLt6dT40M8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-YzQpGAsrjLU18s016LmM7DMJKml0MzKl1bPPYJ/erEk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "10.0.9",
+    "hash": "sha256-644xYxPB+PtwGUTAKJV9wByXHWFkR5Ol0p08wFQwMm4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "10.0.1",
+    "hash": "sha256-NRk0feNE1fgi/hyO0AVDbSGJQRT+9yte6Lpm4Hz/2Bs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "10.0.9",
+    "hash": "sha256-su2q/OZuG7nB3wnUTVcimy3oHSdetFh4hhmjI3f/ym8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Configuration",
+    "version": "10.0.9",
+    "hash": "sha256-fDtKa36XFBzdjwf0g9+mL4y2xE6Dce+YTO6dQaAYYZ8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Console",
+    "version": "10.0.9",
+    "hash": "sha256-i6C3zk+s/ux+tCOnx7gDpoj2hFzBz61hqh0zfbZvHHo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.1",
+    "hash": "sha256-vBiSS1vqAC7eDrpJNT4H3A9qLikCSAepnNRbry0mKnk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "10.0.9",
+    "hash": "sha256-/fc1g1SDJI81nOZRS7W4LZIAC0ssmasqaWhgJK+9rRs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "10.0.9",
+    "hash": "sha256-XVKJrNjPo0hojY5V4xoLxedpvkqtr4GJqkCUhLKSTcQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.1",
+    "hash": "sha256-EXmukq09erT4s+miQpBSYy3IY4HxxKlwEPL43/KoyEc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "10.0.9",
+    "hash": "sha256-WEPtmlEexm6QSFR4ITlBHuUD5/bqMfecOxFe5hkbAPU="
+  },
+  {
+    "pname": "Microsoft.NET.StringTools",
+    "version": "17.4.0",
+    "hash": "sha256-+9uBaUDZ3roUJwyYJUL30Mz+3C6LE16FzfQKgS0Yveo="
+  },
+  {
+    "pname": "Microsoft.NET.StringTools",
+    "version": "18.7.1",
+    "hash": "sha256-sTEk+neir/Qbrn93/T1C3qUl25J0kvD/Mf6ojoBgzQc="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.SolutionPersistence",
+    "version": "1.0.52",
+    "hash": "sha256-KZGPtOXe6Hv8RrkcsgoLKTRyaCScIpQEa2NhNB3iOXw="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Threading",
+    "version": "17.6.40",
+    "hash": "sha256-5HtsgSPV5RdaPREGDvJ7qMOFubb1wMyHwkfTnZs9Zsc="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Threading.Analyzers",
+    "version": "17.6.40",
+    "hash": "sha256-WghLNITEsKTV5pCjogmhfsVD3iO7ghTk0KNrOXzKSS0="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Validation",
+    "version": "17.0.71",
+    "hash": "sha256-0SiADwyfyu+/36jx3UjDX8sANjXZIn20JZNGOlWXNfU="
+  },
+  {
+    "pname": "Microsoft.VisualStudio.Validation",
+    "version": "17.6.11",
+    "hash": "sha256-Lkjp9Ove4+CFP06x/toYpJEiAinuTfn/o+oh0fW3pGM="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "5.0.0",
+    "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
+  },
+  {
+    "pname": "Nerdbank.Streams",
+    "version": "2.10.66",
+    "hash": "sha256-35qyZOVDemtsBYjaZSkzuXGp0mIOSFnCeEHWsUXb5BI="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "2.0.3",
+    "hash": "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.4",
+    "hash": "sha256-8JCB1FdAW681qXP6DFDWvycu1oPyVoxaYgpJ2pUvZSk="
+  },
+  {
+    "pname": "NuGet.Frameworks",
+    "version": "6.14.0",
+    "hash": "sha256-3ViM3R1ucQMEL2hQYsivT86kI6veMQK2xDsiAcFcVQk="
+  },
+  {
+    "pname": "StreamJsonRpc",
+    "version": "2.16.36",
+    "hash": "sha256-XLCQsY7xu67E8E7WJIvjHtk3iobREPCiljW8jNpfi68="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.5.1",
+    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.6.1",
+    "hash": "sha256-sARR6R0Bb77Aka0eNh86cBXh2R1AR/fkinRFWypnPXk="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "9.0.0",
+    "hash": "sha256-+6q5VMeoc5bm4WFsoV6nBXA9dV5pa/O4yW+gOdi8yac="
+  },
+  {
+    "pname": "System.Composition",
+    "version": "10.0.1",
+    "hash": "sha256-t6hzhdjJl8XBIAry9auOZEy8jkKy1qDRmrZxO+IsmXQ="
+  },
+  {
+    "pname": "System.Composition.AttributedModel",
+    "version": "10.0.1",
+    "hash": "sha256-7jwCCz7Ajmpj26JPlMxU7YbwgxuIHuPvhhwWF2Nyhdw="
+  },
+  {
+    "pname": "System.Composition.Convention",
+    "version": "10.0.1",
+    "hash": "sha256-eWrZ0FvOnhhayxT193qjUy2f0cwhf01jJazpgfVb3Fk="
+  },
+  {
+    "pname": "System.Composition.Hosting",
+    "version": "10.0.1",
+    "hash": "sha256-plHdjDS7vCYaP7Uasnx1J9arP9dzDFUl9EPelYj0f0Q="
+  },
+  {
+    "pname": "System.Composition.Runtime",
+    "version": "10.0.1",
+    "hash": "sha256-mOQdwuSR9Akrbvgq0Ujr+uDN+vFjNbOi1ucOUspvEhU="
+  },
+  {
+    "pname": "System.Composition.TypedParts",
+    "version": "10.0.1",
+    "hash": "sha256-5jBc/52m2MQxR5+AkauTEGhza4sNXr9An1IPQNkvffA="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "10.0.1",
+    "hash": "sha256-XmXL//tniOp4RYiXs9HzNbwODjyGYW/bsWO0OuWXAxE="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "10.0.4",
+    "hash": "sha256-IOgtnN6hHNdoZDDvrIBoMzVp+D1SWJ1LwJ+TIUuE3W8="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "4.4.0",
+    "hash": "sha256-+8wGYllXnIxRzy9dLhZFB88GoPj8ivYXS0KUfcivT8I="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "4.5.0",
+    "hash": "sha256-TICO+mteKMC+kUTF2ooLBv2E+pwoSa/4gwcbW4nwN7s="
+  },
+  {
+    "pname": "System.Data.DataSetExtensions",
+    "version": "4.5.0",
+    "hash": "sha256-qppO0L8BpI7cgaStqBhn6YJYFjFdSwpXlRih0XFsaT4="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "7.0.2",
+    "hash": "sha256-8Uawe7mWOQsDzMSAAP16nuGD1FRSajyS8q+cA++MJ8E="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "10.0.1",
+    "hash": "sha256-Yn8jT9uKNnknLsSvtV9hyqfz/5x/aKnZt6XtfQOIdVM="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "10.0.4",
+    "hash": "sha256-gFbdvani74oe8mLZ7bp4Iz5lfP0dJbc+SaUAyko82PY="
+  },
+  {
+    "pname": "System.Diagnostics.EventLog",
+    "version": "6.0.0",
+    "hash": "sha256-zUXIQtAFKbiUMKCrXzO4mOTD5EUphZzghBYKXprowSM="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "10.0.8",
+    "hash": "sha256-/7LqBohsw/Z6/2tDUKoLjQyR8mEbvk4vU2t83EcB2ag="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "7.0.0",
+    "hash": "sha256-W2181khfJUTxLqhuAVRhCa52xZ3+ePGOLIPwEN8WisY="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.4",
+    "hash": "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.5",
+    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.6.3",
+    "hash": "sha256-JgeK63WMmumF6L+FH5cwJgYdpqXrSDcgTQwtIgTHKVU="
+  },
+  {
+    "pname": "System.Numerics.Vectors",
+    "version": "4.6.1",
+    "hash": "sha256-K8UAqG3LAvIDLW2Hf54tbp5KeQgOVyObQZhnnUAx8sc="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.7.0",
+    "hash": "sha256-Fw/CSRD+wajH1MqfKS3Q/sIrUH7GN4K+F+Dx68UPNIg="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.7.0",
+    "hash": "sha256-GUnQeGo/DtvZVQpFnESGq7lJcjB30/KnDY7Kd2G/ElE="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.7.0",
+    "hash": "sha256-V0Wz/UUoNIHdTGS9e1TR89u58zJjo/wPUWw6VaVyclU="
+  },
+  {
+    "pname": "System.Reflection.MetadataLoadContext",
+    "version": "10.0.4",
+    "hash": "sha256-usqt7uNKKWseO94OBJOwPna0lq30W1PhS9MOE+N3VP0="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.0.0",
+    "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.1.2",
+    "hash": "sha256-X2p/U680Zfkr622oc+vg5JYgbDEzE7mLre5DVaayWTc="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "5.0.0",
+    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "10.0.1",
+    "hash": "sha256-B2sQ5rfu4fROzUDbi0A2rHPq27QDmQa3k56MfpE1adA="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "10.0.4",
+    "hash": "sha256-aCbQXMJQrDEOGHCwbY36COSkGHBrZfSnPyTrz6P2Al4="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "4.4.0",
+    "hash": "sha256-Ri53QmFX8I8UH0x4PikQ1ZA07ZSnBUXStd5rBfGWFOE="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "5.0.0",
+    "hash": "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "10.0.8",
+    "hash": "sha256-HGgwNazFJc8PPhjA3p4P3Zgc/Zg8KOk+0uruWPHuo3M="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "7.0.0",
+    "hash": "sha256-tF8qt9GZh/nPy0mEnj6nKLG4Lldpoi/D8xM5lv2CoYQ="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "10.0.8",
+    "hash": "sha256-RTXz0xPQalhyyRLXiu6reSl+dsUXE58GzjYmPP9+hYU="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "7.0.0",
+    "hash": "sha256-KTeMhCWcyYEwG7EkA0VkVvHwo0B2FBs5FpjW3BFNVUE="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.5.4",
+    "hash": "sha256-owSpY8wHlsUXn5xrfYAiu847L6fAKethlvYx97Ri1ng="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.6.3",
+    "hash": "sha256-GrySx1F6Ah6tfnnQt/PHC+dbzg+sfP47OOFX0yJF/xo="
+  }
+]


### PR DESCRIPTION
## Summary

- Add a reproducible Nix flake for the development shell and `csharp-ls` package.
- Add `nix run .#update-deps` for refreshing NuGet dependency hashes.
- Document Nix usage in `CONTRIBUTING.md`.

## Verification

- `nix flake check path:.`
- `nix build path:.#csharp-ls`
- `nix run path:.#csharp-ls -- --version`

Closes #379
Blocked by #380 