### PR TITLE
Feat/expand semantic token support

### DIFF
--- a/src/CSharpLanguageServer/Handlers/SemanticTokens.fs
+++ b/src/CSharpLanguageServer/Handlers/SemanticTokens.fs
@@ -44,11 +44,34 @@ module SemanticTokens =
               (ClassificationTypeNames.PropertyName, "property")
               (ClassificationTypeNames.RecordClassName, "class")
               (ClassificationTypeNames.RecordStructName, "struct")
-              (ClassificationTypeNames.RegexText, "regex")
+              (ClassificationTypeNames.RegexAlternation, "regexAlternation")
+              (ClassificationTypeNames.RegexAnchor, "regexAnchor")
+              (ClassificationTypeNames.RegexCharacterClass, "regexCharacterClass")
+              (ClassificationTypeNames.RegexComment, "regexComment")
+              (ClassificationTypeNames.RegexGrouping, "regexGrouping")
+              (ClassificationTypeNames.RegexOtherEscape, "regexOtherEscape")
+              (ClassificationTypeNames.RegexQuantifier, "regexQuantifier")
+              (ClassificationTypeNames.RegexSelfEscapedCharacter, "regexSelfEscapedCharacter")
+              (ClassificationTypeNames.RegexText, "regexText")
+              (ClassificationTypeNames.StringEscapeCharacter, "stringEscapeCharacter")
               (ClassificationTypeNames.StringLiteral, "string")
               (ClassificationTypeNames.StructName, "struct")
               (ClassificationTypeNames.TypeParameterName, "typeParameter")
-              (ClassificationTypeNames.VerbatimStringLiteral, "string") ]
+              (ClassificationTypeNames.VerbatimStringLiteral, "string")
+
+              // Roslyn's JSON classification constants are internal. Their string values are
+              // nevertheless the public classification contract returned by Classifier.
+              ("json - array", "jsonArray")
+              ("json - comment", "jsonComment")
+              ("json - constructor name", "jsonConstructorName")
+              ("json - keyword", "jsonKeyword")
+              ("json - number", "jsonNumber")
+              ("json - object", "jsonObject")
+              ("json - operator", "jsonOperator")
+              ("json - property name", "jsonPropertyName")
+              ("json - punctuation", "jsonPunctuation")
+              ("json - string", "jsonString")
+              ("json - text", "jsonText") ]
 
     let private classificationModifierMap =
         Map [ (ClassificationTypeNames.StaticSymbol, "static") ]

--- a/src/CSharpLanguageServer/Roslyn/WorkspaceServices.fs
+++ b/src/CSharpLanguageServer/Roslyn/WorkspaceServices.fs
@@ -5,6 +5,9 @@ open System.Collections.Generic
 open System.Reflection
 open System.Threading.Tasks
 open System.Collections.Immutable
+open System.Composition
+open System.Composition.Convention
+open System.Composition.Hosting
 
 open Castle.DynamicProxy
 open Microsoft.CodeAnalysis
@@ -347,10 +350,77 @@ type WorkspaceServicesInterceptor() =
                 invocation.ReturnValue <- updatedReturnValue
 
 
+/// System.Composition only copies metadata properties declared directly on the
+/// concrete metadata attribute type. Roslyn's embedded-language export attribute
+/// derives from a metadata attribute whose Name/Languages/Identifiers properties
+/// are declared on the base type, so those values are otherwise lost. The exports
+/// are discovered, but their metadata is empty and Roslyn filters every embedded
+/// classifier out of the composition.
+///
+/// Preserve the normal attributed model and materialize the inherited Roslyn
+/// embedded-language metadata properties as ordinary ExportMetadata attributes.
+type private RoslynEmbeddedLanguageMefAttributeProvider() =
+    inherit AttributedModelProvider()
+
+    let tryFindInheritedMetadataAttributeType (attributeType: Type) =
+        let rec loop (candidate: Type) =
+            if isNull candidate || candidate = typeof<Attribute> then
+                None
+            elif
+                candidate.FullName = "Microsoft.CodeAnalysis.EmbeddedLanguages.ExportEmbeddedLanguageFeatureServiceAttribute"
+                && candidate.IsDefined(typeof<MetadataAttributeAttribute>, false)
+            then
+                Some candidate
+            else
+                loop candidate.BaseType
+
+        loop attributeType.BaseType
+
+    let inheritedMetadataAttributes (attribute: Attribute) : seq<Attribute> =
+        match tryFindInheritedMetadataAttributeType (attribute.GetType()) with
+        | None -> Seq.empty
+        | Some metadataAttributeType ->
+            metadataAttributeType.GetProperties(
+                BindingFlags.Instance
+                ||| BindingFlags.Public
+                ||| BindingFlags.NonPublic
+                ||| BindingFlags.DeclaredOnly
+            )
+            |> Seq.filter (fun property -> property.CanRead && property.GetIndexParameters().Length = 0)
+            |> Seq.map (fun property ->
+                ExportMetadataAttribute(property.Name, property.GetValue(attribute)) :> Attribute)
+
+    let augmentAttributes (attributes: Attribute seq) : IEnumerable<Attribute> = seq {
+        for attribute in attributes do
+            yield attribute
+            yield! inheritedMetadataAttributes attribute
+    }
+
+    override _.GetCustomAttributes(reflectedType: Type, memberInfo: MemberInfo) =
+        let attributes =
+            if not (memberInfo :? Type) && memberInfo.DeclaringType <> reflectedType then
+                Seq.empty
+            else
+                Attribute.GetCustomAttributes(memberInfo, false)
+
+        augmentAttributes attributes
+
+    override _.GetCustomAttributes(reflectedType: Type, parameterInfo: ParameterInfo) =
+        Attribute.GetCustomAttributes(parameterInfo, false) |> augmentAttributes
+
+
 type CSharpLspHostServices() =
     inherit HostServices()
 
-    member private _.hostServices = MSBuildMefHostServices.DefaultServices
+    static let hostServices =
+        let composition =
+            ContainerConfiguration()
+                .WithAssemblies(MSBuildMefHostServices.DefaultAssemblies, RoslynEmbeddedLanguageMefAttributeProvider())
+                .CreateContainer()
+
+        MefHostServices.Create(composition)
+
+    member private _.hostServices = hostServices
 
     override this.CreateWorkspaceServices(workspace: Workspace) =
         // Ugly but we can't:

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/StringSyntaxSemanticTokenTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/StringSyntaxSemanticTokenTest.cs
@@ -1,0 +1,16 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Project;
+
+internal static class StringSyntaxSemanticTokenTest
+{
+    private static void AcceptRegex([StringSyntax(StringSyntaxAttribute.Regex)] string pattern) { }
+
+    private static void AcceptJson([StringSyntax(StringSyntaxAttribute.Json)] string document) { }
+
+    public static void EmbeddedLanguages()
+    {
+        AcceptRegex(@"$(\a\\)|[^\p{Lu}-a\w\sa-z-[m-p]]+?(?#comment)|(?<name>sub){0,5}?^");
+        AcceptJson(@"[/*comment*/{ 'goo': 0, bar: -Infinity, ""baz"": true }, new Date(), text, 'str'] // comment");
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/SemanticTokenTests.fs
+++ b/tests/CSharpLanguageServer.Tests/SemanticTokenTests.fs
@@ -3,8 +3,13 @@ module CSharpLanguageServer.Tests.SemanticTokenTests
 open System
 open NUnit.Framework
 open Ionide.LanguageServerProtocol.Types
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Classification
+open Microsoft.CodeAnalysis.Host
+open Microsoft.CodeAnalysis.Text
 
 open CSharpLanguageServer.Tests.Tooling
+open CSharpLanguageServer.Roslyn.WorkspaceServices
 
 type DecodedToken =
     { Line: uint
@@ -82,7 +87,7 @@ let testSemanticTokens () =
 
     let legend = semanticTokensOptions.Value.Legend
     Assert.AreEqual([| "static" |], legend.TokenModifiers)
-    Assert.AreEqual(20, legend.TokenTypes.Length)
+    Assert.AreEqual(40, legend.TokenTypes.Length)
 
     // Make sure the server exposes the capability.
     let haveFullSemanticTokenCapability =
@@ -107,7 +112,7 @@ let testSemanticTokens () =
     let semanticToken: SemanticTokens =
         client.Request("textDocument/semanticTokens/full", semanticTokenParams)
 
-    Assert.IsTrue(semanticToken.ResultId.IsNone)
+    Assert.IsTrue semanticToken.ResultId.IsNone
 
     // Test if anything is out-of-bound (that might indicates an underflow)
     Assert.IsFalse(
@@ -116,7 +121,7 @@ let testSemanticTokens () =
         |> Array.fold (fun st -> fun datum -> st || datum[2] > uint32 fileContentsLen) false
     )
 
-    let tokens = semanticToken |> (decodeSemanticToken legend)
+    let tokens = semanticToken |> decodeSemanticToken legend
     Assert.AreEqual(129, tokens.Length)
 
     Assert.AreEqual(
@@ -162,3 +167,115 @@ let testSemanticTokens () =
              TokenModifiers = [||] } |],
         tokens |> Array.take 8
     )
+
+
+[<Test>]
+let testStringSyntaxEmbeddedLanguageSemanticTokens () =
+    use client = activateFixture "genericProject"
+
+    let semanticTokensOptions =
+        client.GetState().ServerCapabilities
+        |> Option.bind (fun c -> c.SemanticTokensProvider)
+        |> Option.bind (fun s ->
+            match s with
+            | U2.C1 c1 -> Some c1
+            | _ -> None)
+
+    Assert.IsTrue semanticTokensOptions.IsSome
+
+    let legend = semanticTokensOptions.Value.Legend
+
+    let expectedEmbeddedLanguageTokenTypes =
+        [| "regexComment"
+           "regexCharacterClass"
+           "regexAnchor"
+           "regexQuantifier"
+           "regexGrouping"
+           "regexAlternation"
+           "regexText"
+           "regexSelfEscapedCharacter"
+           "regexOtherEscape"
+           "jsonComment"
+           "jsonNumber"
+           "jsonString"
+           "jsonKeyword"
+           "jsonText"
+           "jsonOperator"
+           "jsonPunctuation"
+           "jsonArray"
+           "jsonObject"
+           "jsonPropertyName"
+           "jsonConstructorName" |]
+
+    let legendTokenTypes = legend.TokenTypes |> Set.ofArray
+
+    for expectedTokenType in expectedEmbeddedLanguageTokenTypes do
+        Assert.IsTrue(
+            legendTokenTypes.Contains expectedTokenType,
+            sprintf "Expected '%s' in the semantic-token legend" expectedTokenType
+        )
+
+    use file = client.Open "Project/StringSyntaxSemanticTokenTest.cs"
+
+    let semanticTokenParams: SemanticTokensParams =
+        { PartialResultToken = None
+          WorkDoneToken = None
+          TextDocument = { Uri = file.Uri } }
+
+    let semanticToken: SemanticTokens =
+        client.Request("textDocument/semanticTokens/full", semanticTokenParams)
+
+    let actualTokenTypes =
+        semanticToken
+        |> decodeSemanticToken legend
+        |> Array.map _.TokenType
+        |> Set.ofArray
+
+    for expectedTokenType in expectedEmbeddedLanguageTokenTypes do
+        Assert.IsTrue(
+            actualTokenTypes.Contains expectedTokenType,
+            sprintf
+                "Expected semantic token type '%s', got: %s"
+                expectedTokenType
+                (actualTokenTypes |> String.concat ", ")
+        )
+
+let private classifyRegexCommentWithHost (hostServices: HostServices) =
+    use workspace = new AdhocWorkspace(hostServices)
+
+    let project = workspace.AddProject("EmbeddedLanguageProbe", LanguageNames.CSharp)
+
+    let projectWithCoreLib =
+        project.AddMetadataReference(MetadataReference.CreateFromFile(typeof<obj>.Assembly.Location))
+
+    if not (workspace.TryApplyChanges projectWithCoreLib.Solution) then
+        failwith "Could not add the core library metadata reference to the probe workspace"
+
+    let source =
+        """
+class C
+{
+    void M()
+    {
+        var pattern = /* lang=regex */ @"\A(?:a|b)+\z";
+    }
+}
+"""
+
+    let document = workspace.AddDocument(project.Id, "Probe.cs", SourceText.From source)
+
+    Classifier.GetClassifiedSpansAsync(document, TextSpan(0, source.Length))
+    |> Async.AwaitTask
+    |> Async.RunSynchronously
+    |> Seq.map _.ClassificationType
+    |> Set.ofSeq
+
+
+[<Test>]
+let testCSharpLspHostSupportsEmbeddedLanguageClassification () =
+    CSharpLanguageServer.Logging.Logging.setupLogging Microsoft.Extensions.Logging.LogLevel.None
+
+    let classificationTypes =
+        classifyRegexCommentWithHost (CSharpLspHostServices() :> HostServices)
+
+    Assert.That(classificationTypes, Does.Contain ClassificationTypeNames.RegexAnchor)


### PR DESCRIPTION
## Summary

Adds semantic-token support for embedded regex and JSON strings, including strings annotated with `[StringSyntax]`.

The Roslyn MEF composition now preserves the inherited metadata required to discover embedded-language classifiers.

Tested in Neovim 0.12.4

## Before

<img width="1254" height="102" alt="image" src="https://github.com/user-attachments/assets/aa773701-ef44-4acf-8a58-7264a207a643" />

## After

<img width="1254" height="102" alt="image" src="https://github.com/user-attachments/assets/8170d7f9-67aa-43db-ae90-f3d4309887ce" />

## Testing

Added regression coverage for:

* Regex and JSON token types in the semantic-token legend
* `[StringSyntax]`-annotated strings
* Embedded-language classification through `CSharpLspHostServices`

Closes #384 