### PR TITLE
Map hidden diagnostics to hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Map hidden diagnostics to LSP hints
+  - By @alsi-lawr in https://github.com/razzmatazz/csharp-language-server/pull/387
 * Add semantic-token support for embedded regex and JSON strings, including strings annotated with `[StringSyntax]`
   - By @alsi-lawr in https://github.com/razzmatazz/csharp-language-server/pull/385
 * Expand XML documentation comment rendering

--- a/src/CSharpLanguageServer/Roslyn/Conversions.fs
+++ b/src/CSharpLanguageServer/Roslyn/Conversions.fs
@@ -209,6 +209,7 @@ module DiagnosticSeverity =
         | Microsoft.CodeAnalysis.DiagnosticSeverity.Info -> DiagnosticSeverity.Information
         | Microsoft.CodeAnalysis.DiagnosticSeverity.Warning -> DiagnosticSeverity.Warning
         | Microsoft.CodeAnalysis.DiagnosticSeverity.Error -> DiagnosticSeverity.Error
+        | Microsoft.CodeAnalysis.DiagnosticSeverity.Hidden -> DiagnosticSeverity.Hint
         | _ -> DiagnosticSeverity.Warning
 
 module Diagnostic =

--- a/tests/CSharpLanguageServer.Tests/DiagnosticTests.fs
+++ b/tests/CSharpLanguageServer.Tests/DiagnosticTests.fs
@@ -10,6 +10,14 @@ open Ionide.LanguageServerProtocol.Server
 open CSharpLanguageServer.Types
 open CSharpLanguageServer.Tests.Tooling
 
+[<Test>]
+let testHiddenDiagnosticSeverityIsHint () =
+    let severity =
+        CSharpLanguageServer.Roslyn.Conversions.DiagnosticSeverity.fromRoslynDiagnosticSeverity
+            Microsoft.CodeAnalysis.DiagnosticSeverity.Hidden
+
+    Assert.AreEqual(DiagnosticSeverity.Hint, severity)
+
 // This test documents a race: workspace/diagnostic is called while the solution is still
 // loading (simulated via a 3-second SolutionLoadDelay). The server should return no items
 // in that window, but ideally it should block or return a retriable error instead — so the


### PR DESCRIPTION
`Hidden` was falling through to `Warning`.

Fixes #386.
