### PR TITLE
fix(workspace): correct metadata and loose-document resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Fix decompiled metadata navigation stripping trailing characters from type names and failing for nested types; attach loose documents to the nearest containing project in nested-project layouts
+  - By @alsi-lawr in https://github.com/razzmatazz/csharp-language-server/pull/396
 * Fix `textDocument/formatting` ignoring `insertFinalNewline`/`trimFinalNewlines` options; both are now applied after full-document formatting, preserving the document's existing line-ending convention
   - By @alsi-lawr in https://github.com/razzmatazz/csharp-language-server/pull/400
 * Fix a crash where a failed stdout write left the JSON-RPC transport in a broken state instead of shutting it down cleanly and failing pending calls

--- a/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
+++ b/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
@@ -180,13 +180,16 @@ let workspaceFolderParseCSharpDocumentUri (uri: string) (_wf: LspWorkspaceFolder
             match path.IndexOf decompiledPrefix with
             | idx when idx >= 0 ->
                 let projectFilePath = path.Substring(0, idx + ".csproj".Length)
+                let symbolPath = path.Substring(idx + decompiledPrefix.Length)
 
-                let symbolMetadataName =
-                    path.Substring(idx + decompiledPrefix.Length)
-                    |> _.TrimEnd(".cs".ToCharArray())
-                    |> Uri.UnescapeDataString
+                if symbolPath.EndsWith(".cs", StringComparison.Ordinal) then
+                    let symbolMetadataName =
+                        symbolPath.Substring(0, symbolPath.Length - ".cs".Length)
+                        |> Uri.UnescapeDataString
 
-                DecompiledDocumentUri(projectFilePath, symbolMetadataName)
+                    DecompiledDocumentUri(projectFilePath, symbolMetadataName)
+                else
+                    UnrecognizedDocumentUri
             | _ ->
                 match path.IndexOf generatedPrefix with
                 | idx when idx >= 0 ->
@@ -468,7 +471,10 @@ let workspaceFolderProjectForPath (filePath: string) wf : Project option =
         docDir = projectDir || docDir.StartsWith projectDirWithDirSepChar
 
     let findMatchingFileInSolution (sln: Solution) =
-        sln.Projects |> Seq.filter fileIsOnProjectDir |> Seq.tryHead
+        sln.Projects
+        |> Seq.filter fileIsOnProjectDir
+        |> Seq.sortByDescending (fun p -> Path.GetDirectoryName(p.FilePath).Length)
+        |> Seq.tryHead
 
     match wf.Solution with
     | Loaded(_, solution) -> findMatchingFileInSolution solution

--- a/src/CSharpLanguageServer/Roslyn/Symbol.fs
+++ b/src/CSharpLanguageServer/Roslyn/Symbol.fs
@@ -81,10 +81,19 @@ let symbolGetMetadataName' (containingType: INamedTypeSymbol) =
         else
             Some(ns.Name, ns.ContainingNamespace)
 
+    let unfoldContainingType (namedType: INamedTypeSymbol) =
+        if namedType = null then
+            None
+        else
+            Some(namedType.MetadataName, namedType.ContainingType)
+
     let namespaceParts =
         Seq.unfold unfoldNamespace containingType.ContainingNamespace |> Seq.rev
 
-    Seq.append namespaceParts [ containingType.MetadataName ] |> String.concat "."
+    let containingTypeName =
+        Seq.unfold unfoldContainingType containingType |> Seq.rev |> String.concat "+"
+
+    Seq.append namespaceParts [ containingTypeName ] |> String.concat "."
 
 let symbolGetContainingTypeOrThis (symbol: Microsoft.CodeAnalysis.ISymbol) =
     match symbol with

--- a/tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
+++ b/tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="RequestSchedulingTests.fs" />
     <Compile Include="DocumentSyncTests.fs" />
     <Compile Include="WorkspaceTests.fs" />
+    <Compile Include="WorkspaceFolderRegressionTests.fs" />
     <Compile Include="CallHierarchyTests.fs" />
     <Compile Include="FoldingRangeTests.fs" />
     <Compile Include="InlayHintTests.fs" />

--- a/tests/CSharpLanguageServer.Tests/CSharpMetadataTests.fs
+++ b/tests/CSharpLanguageServer.Tests/CSharpMetadataTests.fs
@@ -72,3 +72,59 @@ let ``test csharp/metadata works with no prior LSP request`` () =
     Assert.AreEqual("Project", metadata0.ProjectName)
     Assert.AreEqual("System.String", metadata0.SymbolName)
     Assert.IsTrue(metadata0.Source.StartsWith "using System")
+
+[<Test>]
+let ``csharp metadata preserves type names ending in suffix characters`` () =
+    use client = activateFixture "genericProject"
+
+    let processMetadataUri =
+        client.SolutionDir
+        |> Uri
+        |> string
+        |> _.Substring("file:///".Length)
+        |> sprintf "csharp:/%s/Project/Project.csproj/decompiled/System.Diagnostics.Process.cs"
+
+    let metadataParams: CSharpMetadataParams =
+        { TextDocument = { Uri = processMetadataUri } }
+
+    let metadata: CSharpMetadataResponse =
+        match client.Request("csharp/metadata", metadataParams) with
+        | Some response -> response
+        | None -> failwithf "no response from csharp/metadata for Uri=%s" processMetadataUri
+
+    Assert.AreEqual("System.Diagnostics.Process", metadata.SymbolName)
+    StringAssert.Contains("class Process", metadata.Source)
+
+[<Test>]
+let ``definition resolves members of nested metadata types`` () =
+    use client = activateFixture "genericProject"
+
+    use classFile =
+        client.OpenWithText(
+            "Project/Class.cs",
+            """using System.Collections.Generic;
+class Class
+{
+    bool M(Dictionary<int, string>.Enumerator e) => e.MoveNext();
+}
+"""
+        )
+
+    let definitionParams: DefinitionParams =
+        { TextDocument = { Uri = classFile.Uri }
+          Position = { Line = 3u; Character = 58u }
+          WorkDoneToken = None
+          PartialResultToken = None }
+
+    let definition: Declaration option =
+        client.Request("textDocument/definition", definitionParams)
+
+    let locations =
+        match definition with
+        | Some(U2.C2 locations) when locations.Length > 0 -> locations
+        | _ -> failwithf "metadata locations were expected but received %A" definition
+
+    let location = locations[0]
+
+    StringAssert.EndsWith("/decompiled/System.Collections.Generic.Dictionary%602%2BEnumerator.cs", location.Uri)
+    Assert.That(locations, Has.All.Property("Uri").EqualTo(location.Uri))

--- a/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/App.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/App.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Tests/**/*.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/Tests/Marker.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/Tests/Marker.cs
@@ -1,0 +1,1 @@
+public class NestedMarker {}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/Tests/Scratch.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/Tests/Scratch.cs
@@ -1,0 +1,1 @@
+class Scratch { NestedMarker Field; }

--- a/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/Tests/Tests.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/App/Tests/Tests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Scratch.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/nestedProjects.sln
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/nestedProjects/nestedProjects.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "App\App.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tests", "App\Tests\Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/CSharpLanguageServer.Tests/WorkspaceFolderRegressionTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceFolderRegressionTests.fs
@@ -1,44 +1,24 @@
 module CSharpLanguageServer.Tests.WorkspaceFolderRegressionTests
 
-open System.IO
-
-open Microsoft.CodeAnalysis
 open NUnit.Framework
+open Ionide.LanguageServerProtocol.Types
 
-open CSharpLanguageServer.Lsp.WorkspaceFolder
+open CSharpLanguageServer.Tests.Tooling
 
 [<Test>]
 let ``loose document attaches to nearest containing project`` () =
-    use workspace = new AdhocWorkspace()
+    use client = activateFixture "nestedProjects"
+    use looseDocument = client.Open("App/Tests/Scratch.cs")
 
-    let appDirectory = Path.Combine(Path.GetTempPath(), "App")
-    let testsDirectory = Path.Combine(appDirectory, "Tests")
-    let parentProjectPath = Path.Combine(appDirectory, "App.csproj")
-    let nearestProjectPath = Path.Combine(testsDirectory, "Tests.csproj")
-    let looseDocumentPath = Path.Combine(testsDirectory, "Scratch.cs")
+    let definitionParams: DefinitionParams =
+        { TextDocument = { Uri = looseDocument.Uri }
+          Position = { Line = 0u; Character = 17u }
+          WorkDoneToken = None
+          PartialResultToken = None }
 
-    let projectInfo name filePath =
-        ProjectInfo.Create(
-            ProjectId.CreateNewId(),
-            VersionStamp.Create(),
-            name,
-            name,
-            LanguageNames.CSharp,
-            filePath = filePath
-        )
+    let definition: Declaration option =
+        client.Request("textDocument/definition", definitionParams)
 
-    let solution =
-        workspace.CurrentSolution
-            .AddProject(projectInfo "App" parentProjectPath)
-            .AddProject(projectInfo "Tests" nearestProjectPath)
-
-    let workspaceFolder =
-        { LspWorkspaceFolder.Empty with
-            Solution = Loaded(workspace, solution) }
-
-    let document, _ =
-        workspaceFolderDocumentAdd looseDocumentPath "class Scratch {}" workspaceFolder
-
-    match document with
-    | Some document -> Assert.AreEqual(nearestProjectPath, document.Project.FilePath)
-    | None -> Assert.Fail("the loose document should be attached to a containing project")
+    match definition with
+    | Some(U2.C2 [| location |]) -> StringAssert.EndsWith("/App/Tests/Marker.cs", location.Uri)
+    | _ -> Assert.Fail(sprintf "definition in the nearest containing project was expected but received %A" definition)

--- a/tests/CSharpLanguageServer.Tests/WorkspaceFolderRegressionTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceFolderRegressionTests.fs
@@ -1,0 +1,44 @@
+module CSharpLanguageServer.Tests.WorkspaceFolderRegressionTests
+
+open System.IO
+
+open Microsoft.CodeAnalysis
+open NUnit.Framework
+
+open CSharpLanguageServer.Lsp.WorkspaceFolder
+
+[<Test>]
+let ``loose document attaches to nearest containing project`` () =
+    use workspace = new AdhocWorkspace()
+
+    let appDirectory = Path.Combine(Path.GetTempPath(), "App")
+    let testsDirectory = Path.Combine(appDirectory, "Tests")
+    let parentProjectPath = Path.Combine(appDirectory, "App.csproj")
+    let nearestProjectPath = Path.Combine(testsDirectory, "Tests.csproj")
+    let looseDocumentPath = Path.Combine(testsDirectory, "Scratch.cs")
+
+    let projectInfo name filePath =
+        ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            name,
+            name,
+            LanguageNames.CSharp,
+            filePath = filePath
+        )
+
+    let solution =
+        workspace.CurrentSolution
+            .AddProject(projectInfo "App" parentProjectPath)
+            .AddProject(projectInfo "Tests" nearestProjectPath)
+
+    let workspaceFolder =
+        { LspWorkspaceFolder.Empty with
+            Solution = Loaded(workspace, solution) }
+
+    let document, _ =
+        workspaceFolderDocumentAdd looseDocumentPath "class Scratch {}" workspaceFolder
+
+    match document with
+    | Some document -> Assert.AreEqual(nearestProjectPath, document.Project.FilePath)
+    | None -> Assert.Fail("the loose document should be attached to a containing project")


### PR DESCRIPTION
Fixes #389. Fixes #390. Fixes #393.

## What this changes

- Remove exactly one validated `.cs` suffix from decompiled metadata URIs.
- Include the containing-type chain in CLR metadata names for nested types.
- Attach loose documents to the nearest containing project.

## Proof

### Metadata suffix - #389

I reran the same Neovim definition followed by `csharp/metadata` on `System.Diagnostics.Process`:

```text
textDocument/definition URI:
"csharp:/<workspace>/Probe.csproj/decompiled/System.Diagnostics.Process.cs"
csharp/metadata:
{
  assemblyName = "System.Diagnostics.Process",
  projectName = "Probe",
  sourceStart = "using System.Collections.Generic;",
  symbolName = "System.Diagnostics.Process"
}
```

The metadata response now contains the complete `System.Diagnostics.Process` symbol name and source.

### Nested metadata type - #390

I reran go to definition on `Dictionary<int, string>.Enumerator.MoveNext`:

```text
textDocument/definition:
locations: 3
{
  range = {
    ["end"] = {
      character = 22,
      line = 190
    },
    start = {
      character = 14,
      line = 190
    }
  },
  uri = "csharp:/<workspace>/Probe.csproj/decompiled/System.Collections.Generic.Dictionary%602%2BEnumerator.cs"
}
```

The request now returns locations in the nested `Dictionary`+`Enumerator` metadata document instead of an internal
error.

### Nearest project - #393

I reopened the same excluded `App/Tests/Scratch.cs` loose document and requested hover on both project-local types:

````text
loose document: App/Tests/Scratch.cs
hover on ParentOnly:
nil
hover on NearestOnly:
{
  contents = {
    kind = "markdown",
    value = "```csharp\nNearestOnly\n```"
  }
}
````

## Validation

- The three focused regression tests passed individually.
- The combined branch stack's serial focused suite passed 75/75.
- Fantomas and `git diff --check` passed.
