### PR TITLE
fix(workspace): correct folder routing and empty-folder lifecycle

### DIFF
--- a/src/CSharpLanguageServer/Lsp/Workspace.fs
+++ b/src/CSharpLanguageServer/Lsp/Workspace.fs
@@ -136,9 +136,6 @@ let workspaceSetPhaseReconfiguring (workspace: LspWorkspace) =
         Phase = LspWorkspacePhase.Reconfiguring }
 
 let workspaceFoldersReplaced (workspaceFolders: WorkspaceFolder list) (workspace: LspWorkspace) =
-    if workspaceFolders.Length = 0 then
-        failwith "workspaceFoldersReplaced: at least 1 workspace folder must be provided!"
-
     let folders =
         workspaceFolders
         |> Seq.map (fun f ->
@@ -151,11 +148,20 @@ let workspaceFoldersReplaced (workspaceFolders: WorkspaceFolder list) (workspace
         Folders = folders
         Phase = LspWorkspacePhase.Configured }
 
+let private uriIsWithin (baseUri: string) (uri: string) =
+    let baseUri = baseUri.TrimEnd('/')
+
+    uri.Equals(baseUri, StringComparison.Ordinal)
+    || uri.StartsWith(baseUri + "/", StringComparison.Ordinal)
+
 let workspaceFolder (uri: string) (workspace: LspWorkspace) =
     let workspaceFolderMatchesUri wf =
-        uri.StartsWith wf.Uri || uri.StartsWith(workspaceFolderMetadataUriBase wf)
+        uriIsWithin wf.Uri uri || uriIsWithin (workspaceFolderMetadataUriBase wf) uri
 
-    workspace.Folders |> Seq.tryFind workspaceFolderMatchesUri
+    workspace.Folders
+    |> List.filter workspaceFolderMatchesUri
+    |> List.sortByDescending _.Uri.Length
+    |> List.tryHead
 
 let workspaceFolderUpdated (updatedWf: LspWorkspaceFolder) (workspace: LspWorkspace) =
     let updatedFolders =

--- a/tests/CSharpLanguageServer.Tests/ReconfigurationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/ReconfigurationTests.fs
@@ -114,3 +114,30 @@ let testDidChangeConfigurationAloneTriggersSolutionReload () =
 
     let diagsA1 = getWorkspaceDiagnosticsForUri client projectAUri
     Assert.AreEqual(0, diagsA1.Length)
+
+[<Test>]
+let testRemovingFinalWorkspaceFolderLeavesResponsiveConfiguredWorkspace () =
+    use client = activateFixture "genericProject"
+    use classFile = client.Open("Project/Class.cs")
+
+    let rootFolder: WorkspaceFolder =
+        { Name = "root"
+          Uri = client.SolutionDir |> Uri |> string }
+
+    let folderChangeEvent: DidChangeWorkspaceFoldersParams =
+        { Event =
+            { Added = Array.empty
+              Removed = [| rootFolder |] } }
+
+    client.Notify("workspace/didChangeWorkspaceFolders", folderChangeEvent)
+
+    let hoverParams: HoverParams =
+        { TextDocument = { Uri = classFile.Uri }
+          Position = { Line = 4u; Character = 16u }
+          WorkDoneToken = None }
+
+    let _: Hover option = client.Request("textDocument/hover", hoverParams)
+
+    let workspace = client.GetDebugInfo().workspace
+    Assert.AreEqual("Configured", workspace.phase)
+    Assert.IsTrue(workspace.folders.IsEmpty)

--- a/tests/CSharpLanguageServer.Tests/WorkspaceTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceTests.fs
@@ -10,6 +10,7 @@ open Ionide.LanguageServerProtocol.Types
 open Ionide.LanguageServerProtocol.Server
 
 open CSharpLanguageServer.Tests.Tooling
+open CSharpLanguageServer.Lsp.Workspace
 
 /// Send a workspace/didChangeWatchedFiles notification for a single URI + change type.
 let private notifyFileChanged (client: LspTestClient) (uri: string) (changeType: FileChangeType) =
@@ -222,3 +223,24 @@ let testDidChangeWatchedFilesDeletedCshtmlFileRemovesDocument () =
             let items = cshtmlUri |> getWorkspaceDiagnosticsForUri client
             items.IsEmpty)
         "Expected no workspace diagnostics for deleted .cshtml file"
+
+[<Test>]
+let testWorkspaceFolderRoutingUsesContainmentAndLongestRoot () =
+    let workspaceFolders =
+        [ { Name = "sibling-prefix"
+            Uri = "file:///workspace/app" }
+          { Name = "parent"
+            Uri = "file:///workspace/application" }
+          { Name = "nested"
+            Uri = "file:///workspace/application/src" } ]
+
+    let workspace = LspWorkspace.Empty |> workspaceFoldersReplaced workspaceFolders
+
+    let sibling =
+        workspace |> workspaceFolder "file:///workspace/application/Program.cs"
+
+    let nested =
+        workspace |> workspaceFolder "file:///workspace/application/src/Program.cs"
+
+    Assert.AreEqual(Some "parent", sibling |> Option.map _.Name)
+    Assert.AreEqual(Some "nested", nested |> Option.map _.Name)


### PR DESCRIPTION
Fixes #391. Fixes #394.

## What this changes

- Require an exact URI root or `/` boundary when routing a document to a workspace folder.
- Prefer the longest matching workspace root.
- Allow the supported transition to zero workspace folders without terminating the workspace actor.

## Proof

### Sibling-prefix workspace folders - #391

I reran the same Neovim multi-root probe with `app` listed before `application`, then requested hover from
`application/Program.cs`:

````text
workspace folders:
  file:///<workspace>/app
  file:///<workspace>/application
document: file:///<workspace>/application/Program.cs
hover on ApplicationType:
{
  contents = {
    kind = "markdown",
    value = "```csharp\nApplicationType\n```"
  }
}
````

### Removing the final workspace folder - #394

I reran the same Neovim workspace-removal probe and made another LSP request after the reconfiguration completed:

```text
workspace folders before removal: 1
workspace folders after removal:  0
next LSP request:
{}
client stopped: false
```

The request returns normally and the client remains connected. The local reconfiguration took about four seconds, so
this proof uses a ten-second request window rather than the original one-second failure probe.

## Validation

- Both new focused regressions passed.
- Existing multi-root and metadata routing tests passed.
- The combined branch stack's serial focused suite passed 75/75.
- Fantomas and `git diff --check` passed.
