### PR TITLE
fix(jsonrpc): stop transport after write failure

### DIFF
--- a/src/CSharpLanguageServer/Runtime/JsonRpc.fs
+++ b/src/CSharpLanguageServer/Runtime/JsonRpc.fs
@@ -685,18 +685,30 @@ let processEvent postEvent ev state =
             NotificationHandlers = notificationHandlers
             PendingRead = Some readOp }
 
-    | MessageWriteComplete(_success, msg) ->
+    | MessageWriteComplete(success, msg) ->
         msg.Payload.Dispose()
         msg.CompletionRC |> Option.iter _.Reply()
 
-        match state.WriteQueue, state.StdOut with
-        | nextMsg :: rest, Some stdout ->
-            let writeOp = startMessageWrite log postEvent stdout nextMsg
+        if success then
+            match state.WriteQueue, state.StdOut with
+            | nextMsg :: rest, Some stdout ->
+                let writeOp = startMessageWrite log postEvent stdout nextMsg
+
+                { state with
+                    PendingWrite = Some writeOp
+                    WriteQueue = rest }
+            | _ -> { state with PendingWrite = None }
+        else
+            for queuedMsg in state.WriteQueue do
+                queuedMsg.Payload.Dispose()
+                queuedMsg.CompletionRC |> Option.iter _.Reply()
 
             { state with
-                PendingWrite = Some writeOp
-                WriteQueue = rest }
-        | _ -> { state with PendingWrite = None }
+                StdOut = None
+                PendingWrite = None
+                WriteQueue = [] }
+            |> beginShutdown postEvent None
+            |> tryFireShutdownWaiters
 
     | InboundMessage result ->
         match result with

--- a/tests/CSharpLanguageServer.Tests/JsonRpcTests.fs
+++ b/tests/CSharpLanguageServer.Tests/JsonRpcTests.fs
@@ -40,6 +40,12 @@ let private makeOpenStdin () =
 
     writeEnd, readEnd :> Stream
 
+type private FailingWriteStream() =
+    inherit MemoryStream()
+
+    override _.WriteAsync(_: byte[], _: int, _: int, _: CancellationToken) =
+        System.Threading.Tasks.Task.FromException(IOException("test write failure"))
+
 /// Helper: write a JSON-RPC request into a stream and return a MemoryStream positioned at 0 for reading.
 let private makeInputStream (messages: string list) =
     let ms = new MemoryStream()
@@ -155,6 +161,41 @@ let testBasicMethodInvocationReturnsResponse () =
     Assert.AreEqual(0, stats.WriteQueueLength, "Write queue should be empty after response is flushed")
 
     shutdownJsonRpcTransport _server |> Async.RunSynchronously
+
+[<Test>]
+let testWriteFailureStopsTransportAndFailsPendingOutboundCall () =
+    use clientToServer =
+        new IO.Pipes.AnonymousPipeServerStream(IO.Pipes.PipeDirection.Out)
+
+    use serverStdin =
+        new IO.Pipes.AnonymousPipeClientStream(IO.Pipes.PipeDirection.In, clientToServer.ClientSafePipeHandle)
+
+    use stdout = new FailingWriteStream()
+
+    let server =
+        startJsonRpcTransport serverStdin stdout None (fun _ -> Map.empty, Map.empty)
+
+    let replyTask =
+        sendJsonRpcCall server "test/write-failure" (JsonSerializer.SerializeToElement({| |}))
+        |> Async.StartAsTask
+
+    Assert.IsTrue(
+        replyTask.Wait(TimeSpan.FromSeconds 5.0),
+        "A failed transport write should complete the pending outbound call"
+    )
+
+    match replyTask.Result with
+    | Error err ->
+        Assert.AreEqual(-32099, err.GetProperty("code").GetInt32())
+        Assert.AreEqual("Transport shut down", err.GetProperty("message").GetString())
+    | Ok _ -> Assert.Fail("Expected a transport error after the stdout write failed")
+
+    let stats = getJsonRpcStats server |> Async.RunSynchronously
+    Assert.AreEqual("Stopped", stats.Phase)
+    Assert.AreEqual(0, stats.PendingOutboundCallCount)
+    Assert.AreEqual(0, stats.WriteQueueLength)
+
+    shutdownJsonRpcTransport server |> Async.RunSynchronously
 
 [<Test>]
 let testHandlerReturningEmptyResultProducesResponse () =


### PR DESCRIPTION
Fixes #392.

## What this changes

- Treat a failed stdout write as a terminal transport failure.
- Dispose queued payloads and complete queued notifications.
- Reuse the existing shutdown path to fail pending calls and stop the transport.

## Proof

I reran the same production-transport probe from #392 with its injected `IOException`:

```console
dotnet fsi probe.fsx
```

```text
actual transport state after write failure:
  phase: Stopped
  pending outbound calls: 0
  probe call: completed
```

## Validation

- Failed-write regression: 1/1 passed.
- Full `JsonRpcTests` module: 56/56 passed.
- Fantomas and `git diff --check` passed.
