### PR TITLE
fix(initialization): load config before registrations

### DIFF
--- a/src/CSharpLanguageServer/Handlers/LifeCycle.fs
+++ b/src/CSharpLanguageServer/Handlers/LifeCycle.fs
@@ -122,26 +122,6 @@ module LifeCycle =
         async {
             logger.LogDebug("handleInitialized: \"initialized\" notification received from client")
 
-            logger.LogDebug("handleInitialized: registrationParams..")
-
-            let registrations =
-                getDynamicRegistrations context.Config context.ClientCapabilities
-
-            if registrations.IsEmpty then
-                logger.LogDebug("handleInitialized: no dynamic registrations, skipping client/registerCapability")
-            else
-                let registrationParams = { Registrations = registrations |> List.toArray }
-
-                logger.LogDebug("handleInitialized: ClientRegisterCapability..")
-                // TODO: Retry on error?
-                try
-                    match! lspClient.ClientRegisterCapability registrationParams with
-                    | Ok _ -> ()
-                    | Error error ->
-                        logger.LogWarning("handleInitialized: dynamic cap registration has failed with {error}", error)
-                with ex ->
-                    logger.LogWarning("handleInitialized: dynamic cap registration has failed with {error}", string ex)
-
             logger.LogDebug("handleInitialized: retrieve csharp settings..")
 
             //
@@ -170,6 +150,25 @@ module LifeCycle =
             }
 
             logger.LogInformation("initialize: initial csharp config: {config}", initialConfig |> string)
+
+            logger.LogDebug("handleInitialized: registrationParams..")
+
+            let registrations = getDynamicRegistrations initialConfig context.ClientCapabilities
+
+            if registrations.IsEmpty then
+                logger.LogDebug("handleInitialized: no dynamic registrations, skipping client/registerCapability")
+            else
+                let registrationParams = { Registrations = registrations |> List.toArray }
+
+                logger.LogDebug("handleInitialized: ClientRegisterCapability..")
+                // TODO: Retry on error?
+                try
+                    match! lspClient.ClientRegisterCapability registrationParams with
+                    | Ok _ -> ()
+                    | Error error ->
+                        logger.LogWarning("handleInitialized: dynamic cap registration has failed with {error}", error)
+                with ex ->
+                    logger.LogWarning("handleInitialized: dynamic cap registration has failed with {error}", string ex)
 
             return Ok(), wsUpdate.WithInitializedGate()
         }

--- a/tests/CSharpLanguageServer.Tests/InitializationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InitializationTests.fs
@@ -4,9 +4,11 @@ open System
 
 open NUnit.Framework
 
+open Ionide.LanguageServerProtocol.Server
 open Ionide.LanguageServerProtocol.Types
 
 open CSharpLanguageServer.Tests.Tooling
+open CSharpLanguageServer.Types
 
 let assertHoverWorks (client: LspTestClient) file pos expectedMarkupContent =
     use classFile = client.Open(file)
@@ -268,6 +270,62 @@ let testClientRegisterCapabilityIsNotSentWhenNoDynamicRegistrationsAreRequested 
         client.ServerDidInvoke "client/registerCapability",
         "server must not send client/registerCapability when all dynamicRegistration flags are absent"
     )
+
+[<Test>]
+let testDynamicRegistrationsUsePulledWorkspaceConfiguration () =
+    let diagnosticCapability: DiagnosticClientCapabilities =
+        { DynamicRegistration = Some true
+          RelatedDocumentSupport = None }
+
+    let clientCaps =
+        { defaultClientCapabilities with
+            TextDocument =
+                Some
+                    { defaultClientCapabilities.TextDocument.Value with
+                        Diagnostic = Some diagnosticCapability } }
+
+    let profile =
+        { defaultClientProfile with
+            ClientCapabilities = clientCaps
+            ServerConfig =
+                { defaultClientProfile.ServerConfig with
+                    razorSupport = Some true }
+            // The test harness enables Razor on the CLI by default. Override it so
+            // the workspace/configuration response is the only source enabling it.
+            ExtraArgs = [ "--features"; "\"\"" ] }
+
+    use client = activateFixtureExt "genericProject" profile emptyFixturePatch id
+
+    // Synchronize with the initialized notification before inspecting the RPC log.
+    waitUntilOrTimeout
+        (TimeSpan.FromSeconds 5.0)
+        (fun () -> client.ServerDidInvoke "client/registerCapability")
+        "server never sent client/registerCapability after initialized"
+
+    let registrationParams =
+        client.GetRpcLog()
+        |> Seq.find (fun message ->
+            message.Source = Server
+            && (Some message.Message |> jeStringProp "method") = Some "client/registerCapability")
+        |> _.Message
+        |> Some
+        |> indexJE "params"
+        |> Option.get
+        |> LSPAny.fromJsonElement
+        |> deserialize<RegistrationParams>
+
+    let diagnosticRegistration =
+        registrationParams.Registrations
+        |> Array.find (fun registration -> registration.Method = "textDocument/diagnostic")
+
+    let diagnosticOptions =
+        diagnosticRegistration.RegisterOptions.Value
+        |> deserialize<DiagnosticRegistrationOptions>
+
+    let expectedDocumentSelector: DocumentSelector =
+        [| csharpDocumentFilter |> U2.C1; razorCsharpDocumentFilter |> U2.C1 |]
+
+    Assert.AreEqual(expectedDocumentSelector, diagnosticOptions.DocumentSelector.Value)
 
 [<TestCase(false, TestName = "absent: not sent")>]
 [<TestCase(true, TestName = "Some true: sent")>]


### PR DESCRIPTION
Fixes #395.

## What this changes

- Pull the initial workspace configuration before creating dynamic registrations.
- Build registrations from that retrieved configuration instead of the pre-configuration context.

## Proof

I reran the same Neovim probe with:

```lua
settings = { csharp = { razorSupport = true } }
```

The actual diagnostic registration now includes both selectors:

```text
Neovim workspace setting:
{
  csharp = {
    razorSupport = true
  }
}
registered textDocument/diagnostic selector:
{ {
    language = "csharp",
    pattern = "**/*.cs",
    scheme = "file"
  }, {
    language = "razor",
    pattern = "**/*.cshtml",
    scheme = "file"
  } }
```

## Validation

- Focused regression: 1/1 passed.
- Full `InitializationTests` module: 10/10 passed.
- Fantomas and `git diff --check` passed.
