### PR TITLE
fix(formatting): apply EOF newline options

### DIFF
--- a/src/CSharpLanguageServer/Handlers/DocumentFormatting.fs
+++ b/src/CSharpLanguageServer/Handlers/DocumentFormatting.fs
@@ -44,6 +44,7 @@ module DocumentFormatting =
         let! ct = Async.CancellationToken
         let! options = getDocumentFormattingOptionSet doc lspFormattingOptions
         let! newDoc = Formatter.FormatAsync(doc, options, cancellationToken = ct) |> Async.AwaitTask
+        let! newDoc = normalizeDocumentEndOfFile newDoc options lspFormattingOptions
         let! textEdits = getDocumentDiffAsLspTextEdits newDoc doc
         return textEdits |> Some
     }

--- a/src/CSharpLanguageServer/Roslyn/Document.fs
+++ b/src/CSharpLanguageServer/Roslyn/Document.fs
@@ -4,7 +4,6 @@ open System.IO
 open System.Text
 
 open Microsoft.CodeAnalysis
-open Microsoft.CodeAnalysis.CSharp.Formatting
 open Microsoft.CodeAnalysis.Options
 open Microsoft.CodeAnalysis.Text
 open Microsoft.CodeAnalysis.Formatting
@@ -90,14 +89,55 @@ let getDocumentFormattingOptionSet (doc: Document) (lspFormattingOptions: Format
                 LanguageNames.CSharp,
                 not lspFormattingOptions.InsertSpaces
             )
-            |> match lspFormattingOptions.InsertFinalNewline with
-               | Some insertFinalNewline ->
-                   _.WithChangedOption(CSharpFormattingOptions.NewLineForFinally, insertFinalNewline)
-               | None -> id
-            |> match lspFormattingOptions.TrimFinalNewlines with
-               | Some trimFinalNewlines ->
-                   _.WithChangedOption(CSharpFormattingOptions.NewLineForFinally, not trimFinalNewlines)
-               | None -> id
+}
+
+let normalizeDocumentEndOfFile (doc: Document) (options: OptionSet) (lspFormattingOptions: FormattingOptions option) = async {
+    let insertFinalNewline =
+        (lspFormattingOptions |> Option.bind _.InsertFinalNewline) = Some true
+
+    let trimFinalNewlines =
+        (lspFormattingOptions |> Option.bind _.TrimFinalNewlines) = Some true
+
+    if not insertFinalNewline && not trimFinalNewlines then
+        return doc
+    else
+        let! ct = Async.CancellationToken
+        let! text = doc.GetTextAsync(ct) |> Async.AwaitTask
+        let mutable finalNewlinesStart = text.Length
+        let isNewline char = char = '\r' || char = '\n'
+
+        while finalNewlinesStart > 0 && isNewline text[finalNewlinesStart - 1] do
+            finalNewlinesStart <- finalNewlinesStart - 1
+
+        let normalizedText =
+            if trimFinalNewlines && finalNewlinesStart < text.Length then
+                let newlineLength =
+                    if
+                        text[finalNewlinesStart] = '\r'
+                        && finalNewlinesStart < text.Length - 1
+                        && text[finalNewlinesStart + 1] = '\n'
+                    then
+                        2
+                    else
+                        1
+
+                let newline = text.ToString(TextSpan(finalNewlinesStart, newlineLength))
+                let finalNewlines = TextSpan.FromBounds(finalNewlinesStart, text.Length)
+                text.WithChanges(TextChange(finalNewlines, newline))
+            elif insertFinalNewline && finalNewlinesStart = text.Length then
+                let newline =
+                    text.Lines
+                    |> Seq.rev
+                    |> Seq.tryPick (fun line ->
+                        let span = TextSpan.FromBounds(line.End, line.EndIncludingLineBreak)
+                        if span.IsEmpty then None else Some(text.ToString(span)))
+                    |> Option.defaultWith (fun () -> options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp))
+
+                text.WithChanges(TextChange(TextSpan(text.Length, 0), newline))
+            else
+                text
+
+        return doc.WithText(normalizedText)
 }
 
 let sourceTextFromFile (filename: string) : SourceText =

--- a/tests/CSharpLanguageServer.Tests/DocumentFormattingTests.fs
+++ b/tests/CSharpLanguageServer.Tests/DocumentFormattingTests.fs
@@ -7,6 +7,12 @@ open Ionide.LanguageServerProtocol.Types
 
 open CSharpLanguageServer.Tests.Tooling
 
+let private formattingOptionsProfile =
+    { defaultClientProfile with
+        ServerConfig =
+            { defaultClientProfile.ServerConfig with
+                applyFormattingOptions = Some true } }
+
 [<Test>]
 let testEditorConfigFormatting () =
     use client = activateFixture "projectWithEditorConfig"
@@ -37,3 +43,70 @@ let testEditorConfigFormatting () =
 
         Assert.AreEqual(expectedClassContents, actualClassContents)
     | None -> failwith "Some TextEdit's were expected"
+
+[<Test>]
+let testEofFormattingOptionsNormalizeNewlinesWithoutChangingFinallyPlacement () =
+    use client =
+        activateFixtureExt "genericProject" formattingOptionsProfile emptyFixturePatch id
+
+    let sourceWithoutFinalNewline =
+        """class C
+{
+    void M()
+    {
+        try { }
+        finally { }
+    }
+}
+"""
+        |> fun source -> source.TrimEnd().ReplaceLineEndings("\r\n")
+
+    let sourceWithFinalNewline = sourceWithoutFinalNewline + "\r\n"
+    let sourceWithSurplusFinalNewlines = sourceWithoutFinalNewline + "\r\n\r\n\r\n"
+    use classFile = client.OpenWithText("Project/Class.cs", sourceWithoutFinalNewline)
+
+    let assertFormatting caseName source insertFinalNewline trimFinalNewlines expected =
+        classFile.Change(source)
+
+        let formattingParams: DocumentFormattingParams =
+            { TextDocument = { Uri = classFile.Uri }
+              WorkDoneToken = None
+              Options =
+                { TabSize = 4u
+                  InsertSpaces = true
+                  TrimTrailingWhitespace = None
+                  InsertFinalNewline = insertFinalNewline
+                  TrimFinalNewlines = trimFinalNewlines } }
+
+        let textEdits: TextEdit[] option =
+            client.Request("textDocument/formatting", formattingParams)
+
+        match textEdits with
+        | Some textEdits ->
+            let actual = classFile.GetFileContentsWithTextEditsApplied(textEdits)
+            Assert.AreEqual(expected, actual, caseName)
+        | None -> failwith "Some TextEdit's were expected"
+
+    assertFormatting "insert true" sourceWithoutFinalNewline (Some true) None sourceWithFinalNewline
+
+    assertFormatting
+        "insert true with existing newlines"
+        sourceWithSurplusFinalNewlines
+        (Some true)
+        None
+        sourceWithSurplusFinalNewlines
+
+    assertFormatting "insert false" sourceWithSurplusFinalNewlines (Some false) None sourceWithSurplusFinalNewlines
+
+    assertFormatting "trim true" sourceWithSurplusFinalNewlines None (Some true) sourceWithFinalNewline
+
+    assertFormatting "trim false" sourceWithoutFinalNewline None (Some false) sourceWithoutFinalNewline
+
+    assertFormatting
+        "insert and trim true"
+        sourceWithSurplusFinalNewlines
+        (Some true)
+        (Some true)
+        sourceWithFinalNewline
+
+    assertFormatting "options absent" sourceWithSurplusFinalNewlines None None sourceWithSurplusFinalNewlines


### PR DESCRIPTION
Fixes #388.

## What this changes

- Remove the accidental mapping from `insertFinalNewline` and `trimFinalNewlines` to Roslyn's `NewLineForFinally`
  option.
- Apply both EOF options to the document after full-document Roslyn formatting.
- Preserve the document's existing line-ending convention, falling back to Roslyn's configured newline when the file has
  none.

## Proof

I reran the Neovim formatting probe on a document with no final newline and one with three final newlines:

```lua
vim.lsp.buf.format({ formatting_options = { insertFinalNewline = true } })
vim.lsp.buf.format({ formatting_options = { trimFinalNewlines = true } })
vim.lsp.buf.format({ formatting_options = { insertFinalNewline = false } })
```

The actual formatted documents are printed as escaped strings so their EOF state is visible:

```text
insertFinalNewline=true:
"class C\n{\n    void M()\n    {\n        try { }\n        finally { }\n    }\n}\n"
trimFinalNewlines=true:
"class C\n{\n    void M()\n    {\n        try { }\n        finally { }\n    }\n}\n"
insertFinalNewline=false:
"class C\n{\n    void M()\n    {\n        try { }\n        finally { }\n    }\n}"
```

`insertFinalNewline` adds one newline, `trimFinalNewlines` collapses the surplus to one, and `false` leaves the missing
newline unchanged. None of the requests change `finally` placement.

## Validation

- `DocumentFormattingTests`: 2/2 passed, including seven EOF-option cases.
- Fantomas and `git diff --check` passed.
