### PR TITLE
Fix workspace diagnostic result IDs after document edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Fix workspace pull diagnostics returning `unchanged` after source document edits, which could leave clients with stale results
+  - Reported in https://github.com/razzmatazz/csharp-language-server/issues/401
 * Fix decompiled metadata navigation stripping trailing characters from type names and failing for nested types; attach loose documents to the nearest containing project in nested-project layouts
   - By @alsi-lawr in https://github.com/razzmatazz/csharp-language-server/pull/396
 * Fix `textDocument/formatting` ignoring `insertFinalNewline`/`trimFinalNewlines` options; both are now applied after full-document formatting, preserving the document's existing line-ending convention

--- a/src/CSharpLanguageServer/Handlers/Diagnostic.fs
+++ b/src/CSharpLanguageServer/Handlers/Diagnostic.fs
@@ -56,8 +56,11 @@ module Diagnostic =
 
             Some registration
 
-    let private projectResultId (analyzersEnabled: bool) (project: Microsoft.CodeAnalysis.Project) =
-        sprintf "%s/%b" (string project.Version) analyzersEnabled
+    let private projectResultId (analyzersEnabled: bool) (project: Microsoft.CodeAnalysis.Project) = async {
+        let! ct = Async.CancellationToken
+        let! version = project.GetDependentVersionAsync(ct) |> Async.AwaitTask
+        return sprintf "%s/%b" (string version) analyzersEnabled
+    }
 
     let private diagnosticIsToBeListed (uri: string) (d: Microsoft.CodeAnalysis.Diagnostic) =
         if uri.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase) then
@@ -117,7 +120,10 @@ module Diagnostic =
                     // VS Code substitutes the document-level pull state (which has resultId=None)
                     // over the workspace pull state for any open file, causing previousResultIds
                     // to be empty on every poll and triggering a perpetual full re-scan.
-                    let resultId = project |> Option.map (projectResultId analyzersEnabled)
+                    let! resultId =
+                        match project with
+                        | Some project -> projectResultId analyzersEnabled project |> Async.map Some
+                        | None -> async.Return None
 
                     return
                         { emptyReport with
@@ -149,19 +155,29 @@ module Diagnostic =
                 let analyzersEnabled = config.analyzersEnabled |> Option.defaultValue false
                 // Include analyzersEnabled in the resultId so that toggling the setting
                 // invalidates any cached "unchanged" result the client holds.
-                let resultId = project |> projectResultId analyzersEnabled
+                let! resultId = project |> projectResultId analyzersEnabled
 
-                // Collect URIs the client already holds for this exact project version.
-                // If any exist, the client received the full set on a previous poll —
-                // emit Unchanged for each and skip Roslyn entirely.
-                let clientKnownUris =
+                let pathToUri path = workspaceFolderPathToUri path wf
+
+                let projectDocumentUris =
+                    project.Documents
+                    |> Seq.choose (fun d -> d.FilePath |> Option.ofObj)
+                    |> Seq.map pathToUri
+                    |> Set.ofSeq
+
+                let clientKnownResultsForProject =
                     knownResultIds
                     |> Map.toSeq
-                    |> Seq.choose (fun (uri, knownId) -> if knownId = resultId then Some uri else None)
+                    |> Seq.filter (fun (uri, _) -> projectDocumentUris.Contains uri)
                     |> Array.ofSeq
 
-                if clientKnownUris.Length > 0 then
-                    for uri in clientKnownUris do
+                let clientHasCurrentProjectVersion =
+                    clientKnownResultsForProject.Length > 0
+                    && clientKnownResultsForProject
+                       |> Array.forall (fun (_, knownId) -> knownId = resultId)
+
+                if clientHasCurrentProjectVersion then
+                    for uri, _ in clientKnownResultsForProject do
                         let documentReport: WorkspaceDocumentDiagnosticReport =
                             U2.C2
                                 { Kind = "unchanged"
@@ -177,8 +193,6 @@ module Diagnostic =
                     match compilation |> Option.ofObj with
                     | None -> ()
                     | Some compilation ->
-                        let pathToUri path = workspaceFolderPathToUri path wf
-
                         // Collect file paths of source-generated documents (IIncrementalGenerator
                         // output) so we can suppress their diagnostics. Users have no control over
                         // generated code, so surfacing those diagnostics would only cause noise.
@@ -242,17 +256,9 @@ module Diagnostic =
                         // resultId.  On the next poll the client sends those mismatched
                         // resultIds, so the owning project sees them as stale and re-emits
                         // real diagnostics — producing the 0 → N → 0 cycle.
-                        let projectDocumentUris =
-                            project.Documents
-                            |> Seq.choose (fun d -> d.FilePath |> Option.ofObj)
-                            |> Seq.map pathToUri
-                            |> Set.ofSeq
-
                         let clientKnownUrisForProject =
-                            knownResultIds
-                            |> Map.toSeq
+                            clientKnownResultsForProject
                             |> Seq.map fst
-                            |> Seq.filter (fun uri -> projectDocumentUris.Contains uri)
                             |> Seq.filter (fun uri -> not (diagnosticsByDocument.ContainsKey uri))
 
                         for uri in clientKnownUrisForProject do

--- a/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
+++ b/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
@@ -147,6 +147,95 @@ let testWorkspaceDiagnosticsIncludeAnalyzerDiagnostics () =
     | _ -> failwith "'Some' was expected"
 
 [<Test>]
+let testWorkspaceDiagnosticResultIdChangesAfterDocumentEdit () =
+    use client =
+        activateFixtureExt "projectWithEditorConfigAnalyzers" analyzerClientProfile prebuildProject id
+
+    use classFile = client.Open("Project/Class.cs")
+    let consumerUri = "Project/Consumer.cs" |> fileUriForProjectDir client.SolutionDir
+
+    let initialParams: WorkspaceDiagnosticParams =
+        { WorkDoneToken = None
+          PartialResultToken = None
+          Identifier = None
+          PreviousResultIds = Array.empty }
+
+    let initialReport: WorkspaceDiagnosticReport option =
+        client.Request("workspace/diagnostic", initialParams)
+
+    let initialFullReports =
+        match initialReport with
+        | Some report ->
+            report.Items
+            |> Array.choose (function
+                | U2.C1 fullReport -> Some fullReport
+                | U2.C2 _ -> None)
+        | None -> failwith "workspace diagnostics were expected"
+
+    let initialClassReport =
+        initialFullReports |> Array.find (fun report -> report.Uri = classFile.Uri)
+
+    let initialConsumerReport =
+        initialFullReports |> Array.find (fun report -> report.Uri = consumerUri)
+
+    let initialResultId = initialClassReport.ResultId |> Option.get
+
+    Assert.That(initialClassReport.Items |> Array.choose _.Code |> Array.map string, Does.Contain("IDE0051"))
+    Assert.That(initialConsumerReport.Items |> Array.choose _.Code |> Array.map string, Does.Contain("CS0122"))
+    Assert.That(initialConsumerReport.ResultId, Is.EqualTo(Some initialResultId))
+
+    classFile.Change(
+        """public class MyClass
+{
+    public int Value { get; set; }
+}
+"""
+    )
+
+    let documentParams: DocumentDiagnosticParams =
+        { WorkDoneToken = None
+          PartialResultToken = None
+          TextDocument = { Uri = classFile.Uri }
+          Identifier = None
+          PreviousResultId = Some initialResultId }
+
+    let updatedDocumentReport: DocumentDiagnosticReport option =
+        client.Request("textDocument/diagnostic", documentParams)
+
+    let updatedDocumentResultId =
+        match updatedDocumentReport with
+        | Some(U2.C1 fullReport) -> fullReport.ResultId |> Option.get
+        | _ -> failwith "updated document diagnostics were expected"
+
+    Assert.That(updatedDocumentResultId, Is.Not.EqualTo(initialResultId))
+
+    let updatedParams: WorkspaceDiagnosticParams =
+        { initialParams with
+            PreviousResultIds =
+                [| { Uri = classFile.Uri
+                     Value = updatedDocumentResultId }
+                   { Uri = consumerUri
+                     Value = initialResultId } |] }
+
+    let updatedReport: WorkspaceDiagnosticReport option =
+        client.Request("workspace/diagnostic", updatedParams)
+
+    match updatedReport with
+    | Some report ->
+        match
+            report.Items
+            |> Array.tryFind (function
+                | U2.C1 fullReport -> fullReport.Uri = consumerUri
+                | U2.C2 unchangedReport -> unchangedReport.Uri = consumerUri)
+        with
+        | Some(U2.C1 fullReport) ->
+            Assert.That(fullReport.ResultId, Is.EqualTo(Some updatedDocumentResultId))
+            Assert.That(fullReport.Items |> Array.choose _.Code |> Array.map string, Does.Not.Contain("CS0122"))
+        | Some(U2.C2 _) -> failwith "Consumer.cs diagnostics must not be reported as unchanged"
+        | None -> failwith "updated Consumer.cs diagnostics were expected"
+    | None -> failwith "updated workspace diagnostics were expected"
+
+[<Test>]
 let testAnalyzerPipelineDoesNotCrashWhenNoAnalyzersPresent () =
     // Verify that the analyzer pipeline is robust when a project has no analyzer references
     // configured with diagnostic severity rules. Uses the genericProject fixture which has

--- a/tests/CSharpLanguageServer.Tests/Fixtures/projectWithEditorConfigAnalyzers/Project/Consumer.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/projectWithEditorConfigAnalyzers/Project/Consumer.cs
@@ -1,0 +1,4 @@
+public class Consumer
+{
+    public int Read(MyClass instance) => instance.Value;
+}


### PR DESCRIPTION
Fixes #401.

## What changed

- Build diagnostic result IDs from Roslyn's dependent project version, which includes
  source document changes.
- Only return project-wide `unchanged` reports when every result ID the client holds for
  that project matches the current version.
- Cover the Neovim flow where the edited document has a new result ID while a dependent
  document still has the previous workspace result ID.
- Add the fix to the changelog.

## Neovim proof

I ran csharp-ls over stdio from Neovim 0.12.4 against a two-file project. `Consumer.cs`
referenced a missing `Provider.Value`; I then added that property in the open `Provider.cs`
buffer, saved, and requested workspace diagnostics again.

Before:

```text
## initial workspace diagnostics
CS0117: 'Provider' does not contain a definition for 'Value'

## Provider.cs after edit
namespace Probe;

public static class Provider
{
    public static int Value => 42;
}

## workspace diagnostics after edit
CS0117: 'Provider' does not contain a definition for 'Value'
```

After:

```text
## initial workspace diagnostics
CS0117: 'Provider' does not contain a definition for 'Value'

## Provider.cs after edit
namespace Probe;

public static class Provider
{
    public static int Value => 42;
}

## workspace diagnostics after edit
diagnostics: (none)
```

The fixed second workspace response is a full empty report for `Consumer.cs` with the new
result ID, so Neovim clears the stale diagnostic.

## Validation

```text
nix develop -c dotnet test --filter FullyQualifiedName~testWorkspaceDiagnosticResultIdChangesAfterDocumentEdit
Passed: 1, Failed: 0

nix develop -c dotnet test --filter FullyQualifiedName~AnalyzerTests
Passed: 4, Failed: 0

nix develop -c dotnet test
Passed: 292, Failed: 0, Skipped: 0
```
