### PR TITLE
perf(diagnostics): share analyzer results across document requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Speed up analyzer-enabled diagnostics by sharing project-wide analyzer results across document requests for the same Roslyn solution snapshot
+  - Reported in https://github.com/razzmatazz/csharp-language-server/issues/403
 * Fix workspace pull diagnostics returning `unchanged` after source document edits, which could leave clients with stale results
   - Reported in https://github.com/razzmatazz/csharp-language-server/issues/401
 * Fix decompiled metadata navigation stripping trailing characters from type names and failing for nested types; attach loose documents to the nearest containing project in nested-project layouts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Speed up analyzer-enabled diagnostics by sharing project-wide analyzer results across document requests for the same Roslyn solution snapshot
+  - Reported in https://github.com/razzmatazz/csharp-language-server/issues/403
 * Fix `.slnf` solution filters being ignored when the declared project set is read from the solution: the set was read from the filter's parent solution, so on a filtered solution the load progress reported counts like `(74/358)` with the percentage stuck at 20, and the workspace-global `TargetFramework` intersection wrongly included projects the filter excludes
   - By @pbednarcik
 * Fix `textDocument/completion` (and other interactive requests) stalling when analyzers are enabled on a multi-project solution: `workspace/diagnostic` now analyzes one project at a time instead of fanning out across every project concurrently

--- a/src/CSharpLanguageServer/Handlers/Diagnostic.fs
+++ b/src/CSharpLanguageServer/Handlers/Diagnostic.fs
@@ -102,7 +102,8 @@ module Diagnostic =
 
                     let! allDiags =
                         match project, analyzersEnabled with
-                        | Some project, true -> getDocumentDiagnosticsWithAnalyzers project semanticModel
+                        | Some project, true ->
+                            getDocumentDiagnosticsWithAnalyzers wf.AnalyzerDiagnostics project semanticModel
                         | _ -> async {
                             let diags = semanticModel.GetDiagnostics(cancellationToken = ct)
                             return diags |> List.ofSeq
@@ -212,7 +213,7 @@ module Diagnostic =
 
                         let! allDiags =
                             if analyzersEnabled then
-                                getCompilationDiagnosticsWithAnalyzers project compilation
+                                getCompilationDiagnosticsWithAnalyzers wf.AnalyzerDiagnostics project compilation
                             else
                                 async { return compilation.GetDiagnostics() |> List.ofSeq }
 

--- a/src/CSharpLanguageServer/Handlers/Diagnostic.fs
+++ b/src/CSharpLanguageServer/Handlers/Diagnostic.fs
@@ -101,7 +101,8 @@ module Diagnostic =
 
                     let! allDiags =
                         match project, analyzersEnabled with
-                        | Some project, true -> getDocumentDiagnosticsWithAnalyzers project semanticModel
+                        | Some project, true ->
+                            getDocumentDiagnosticsWithAnalyzers wf.AnalyzerDiagnostics project semanticModel
                         | _ -> async {
                             let diags = semanticModel.GetDiagnostics(cancellationToken = ct)
                             return diags |> List.ofSeq
@@ -202,7 +203,7 @@ module Diagnostic =
 
                         let! allDiags =
                             if analyzersEnabled then
-                                getCompilationDiagnosticsWithAnalyzers project compilation
+                                getCompilationDiagnosticsWithAnalyzers wf.AnalyzerDiagnostics project compilation
                             else
                                 async { return compilation.GetDiagnostics() |> List.ofSeq }
 

--- a/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
+++ b/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
@@ -18,6 +18,7 @@ open CSharpLanguageServer.Util
 open CSharpLanguageServer.Types
 open CSharpLanguageServer.Roslyn.Symbol
 open CSharpLanguageServer.Roslyn.Solution
+open CSharpLanguageServer.Roslyn.Analyzers
 open CSharpLanguageServer.Roslyn.Conversions
 open CSharpLanguageServer.Logging
 
@@ -50,6 +51,8 @@ type LspWorkspaceFolder =
 
         Solution: LspWorkspaceFolderSolution
 
+        AnalyzerDiagnostics: AnalyzerDiagnosticsCache
+
         /// key is (project.Path * symbol metadata name)
         DecompiledSymbolMetadata: Map<string * string, LspWorkspaceDecompiledMetadataDocument>
 
@@ -64,6 +67,7 @@ type LspWorkspaceFolder =
           SolutionPathOverride = None
           Generation = Guid.NewGuid()
           Solution = Uninitialized
+          AnalyzerDiagnostics = AnalyzerDiagnosticsCache()
           DecompiledSymbolMetadata = Map.empty
           OpenDocs = Map.empty
           PushDiagnosticsBacklogUpdatePending = false }
@@ -756,5 +760,6 @@ let workspaceFolderTeardown (wf: LspWorkspaceFolder) : LspWorkspaceFolder =
     { wf with
         Generation = Guid.NewGuid()
         Solution = Uninitialized
+        AnalyzerDiagnostics = AnalyzerDiagnosticsCache()
         DecompiledSymbolMetadata = Map.empty
         OpenDocs = Map.empty }

--- a/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
+++ b/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
@@ -18,6 +18,7 @@ open CSharpLanguageServer.Util
 open CSharpLanguageServer.Types
 open CSharpLanguageServer.Roslyn.Symbol
 open CSharpLanguageServer.Roslyn.Solution
+open CSharpLanguageServer.Roslyn.Analyzers
 open CSharpLanguageServer.Roslyn.Conversions
 open CSharpLanguageServer.Logging
 
@@ -50,6 +51,8 @@ type LspWorkspaceFolder =
 
         Solution: LspWorkspaceFolderSolution
 
+        AnalyzerDiagnostics: AnalyzerDiagnosticsCache
+
         /// key is (project.Path * symbol metadata name)
         DecompiledSymbolMetadata: Map<string * string, LspWorkspaceDecompiledMetadataDocument>
 
@@ -64,6 +67,7 @@ type LspWorkspaceFolder =
           SolutionPathOverride = None
           Generation = Guid.NewGuid()
           Solution = Uninitialized
+          AnalyzerDiagnostics = AnalyzerDiagnosticsCache()
           DecompiledSymbolMetadata = Map.empty
           OpenDocs = Map.empty
           PushDiagnosticsBacklogUpdatePending = false }
@@ -814,5 +818,6 @@ let workspaceFolderTeardown (wf: LspWorkspaceFolder) : LspWorkspaceFolder =
     { wf with
         Generation = Guid.NewGuid()
         Solution = Uninitialized
+        AnalyzerDiagnostics = AnalyzerDiagnosticsCache()
         DecompiledSymbolMetadata = Map.empty
         OpenDocs = Map.empty }

--- a/src/CSharpLanguageServer/Roslyn/Analyzers.fs
+++ b/src/CSharpLanguageServer/Roslyn/Analyzers.fs
@@ -12,8 +12,17 @@ open Microsoft.CodeAnalysis.Diagnostics
 
 type private SolutionAnalysisCache = ConcurrentDictionary<ProjectId, Lazy<Task<ImmutableArray<Diagnostic>>>>
 
-let private solutionAnalysisCaches =
-    ConditionalWeakTable<Solution, SolutionAnalysisCache>()
+/// Keyed by Solution snapshot; an edited snapshot misses.
+type AnalyzerDiagnosticsCache() =
+    let solutionCaches = ConditionalWeakTable<Solution, SolutionAnalysisCache>()
+
+    member _.GetOrStartAnalysis
+        (solution: Solution, projectId: ProjectId, startAnalysis: unit -> Task<ImmutableArray<Diagnostic>>)
+        : Task<ImmutableArray<Diagnostic>> =
+        solutionCaches
+            .GetValue(solution, fun _ -> SolutionAnalysisCache())
+            .GetOrAdd(projectId, fun _ -> lazy (startAnalysis ()))
+            .Value
 
 let private projectAnalyzers (project: Project) =
     project.AnalyzerReferences
@@ -21,25 +30,21 @@ let private projectAnalyzers (project: Project) =
     |> ImmutableArray.CreateRange
 
 let private getSharedProjectAnalysis
+    (cache: AnalyzerDiagnosticsCache)
     (project: Project)
     (compilation: Compilation)
     (analyzers: ImmutableArray<DiagnosticAnalyzer>)
     : Async<ImmutableArray<Diagnostic>> =
     async {
-        let solutionCache =
-            solutionAnalysisCaches.GetValue(project.Solution, fun _ -> SolutionAnalysisCache())
-
         let analysisTask =
-            solutionCache
-                .GetOrAdd(
-                    project.Id,
-                    fun _ ->
-                        lazy
-                            // Cancellation applies to each waiter, not to the shared analysis.
-                            let cwa = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions)
-                            cwa.GetAllDiagnosticsAsync(CancellationToken.None)
-                )
-                .Value
+            cache.GetOrStartAnalysis(
+                project.Solution,
+                project.Id,
+                fun () ->
+                    // Cancellation applies to each waiter, not to the shared analysis.
+                    let cwa = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions)
+                    cwa.GetAllDiagnosticsAsync(CancellationToken.None)
+            )
 
         let! ct = Async.CancellationToken
         return! analysisTask.WaitAsync(ct) |> Async.AwaitTask
@@ -47,17 +52,22 @@ let private getSharedProjectAnalysis
 
 /// Returns compiler diagnostics + all analyzer diagnostics for an entire compilation.
 /// Falls back to compiler-only if the project has no analyzer references.
-let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Compilation) : Async<Diagnostic list> = async {
-    let! ct = Async.CancellationToken
+let getCompilationDiagnosticsWithAnalyzers
+    (cache: AnalyzerDiagnosticsCache)
+    (project: Project)
+    (compilation: Compilation)
+    : Async<Diagnostic list> =
+    async {
+        let! ct = Async.CancellationToken
 
-    let analyzers = projectAnalyzers project
+        let analyzers = projectAnalyzers project
 
-    if analyzers.IsEmpty then
-        return compilation.GetDiagnostics(ct) |> List.ofSeq
-    else
-        let! allDiags = getSharedProjectAnalysis project compilation analyzers
-        return allDiags |> List.ofSeq
-}
+        if analyzers.IsEmpty then
+            return compilation.GetDiagnostics(ct) |> List.ofSeq
+        else
+            let! allDiags = getSharedProjectAnalysis cache project compilation analyzers
+            return allDiags |> List.ofSeq
+    }
 
 /// Returns compiler diagnostics + analyzer diagnostics for a single document's semantic model.
 /// Falls back to compiler-only if the project has no analyzer references.
@@ -66,22 +76,27 @@ let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Comp
 /// path rather than GetAnalyzerSemanticDiagnosticsAsync, because some IDE analyzers (e.g.
 /// IDE0040 "accessibility modifiers") emit diagnostics whose reported location causes them
 /// to be missed by the span-based semantic filter.
-let getDocumentDiagnosticsWithAnalyzers (project: Project) (semanticModel: SemanticModel) : Async<Diagnostic list> = async {
-    let! ct = Async.CancellationToken
+let getDocumentDiagnosticsWithAnalyzers
+    (cache: AnalyzerDiagnosticsCache)
+    (project: Project)
+    (semanticModel: SemanticModel)
+    : Async<Diagnostic list> =
+    async {
+        let! ct = Async.CancellationToken
 
-    let analyzers = projectAnalyzers project
+        let analyzers = projectAnalyzers project
 
-    if analyzers.IsEmpty then
-        return semanticModel.GetDiagnostics(cancellationToken = ct) |> List.ofSeq
-    else
-        let! allDiags = getSharedProjectAnalysis project semanticModel.Compilation analyzers
+        if analyzers.IsEmpty then
+            return semanticModel.GetDiagnostics(cancellationToken = ct) |> List.ofSeq
+        else
+            let! allDiags = getSharedProjectAnalysis cache project semanticModel.Compilation analyzers
 
-        // Filter to only diagnostics whose source location is within this document.
-        // Diagnostics with no source location (e.g. compilation-level errors) are excluded
-        // so they aren't duplicated across every open document.
-        let mappedPathMatchesDocFilePath (d: Diagnostic) =
-            let path = d.Location.GetMappedLineSpan().Path
-            path = semanticModel.SyntaxTree.FilePath
+            // Filter to only diagnostics whose source location is within this document.
+            // Diagnostics with no source location (e.g. compilation-level errors) are excluded
+            // so they aren't duplicated across every open document.
+            let mappedPathMatchesDocFilePath (d: Diagnostic) =
+                let path = d.Location.GetMappedLineSpan().Path
+                path = semanticModel.SyntaxTree.FilePath
 
-        return allDiags |> Seq.filter mappedPathMatchesDocFilePath |> List.ofSeq
-}
+            return allDiags |> Seq.filter mappedPathMatchesDocFilePath |> List.ofSeq
+    }

--- a/src/CSharpLanguageServer/Roslyn/Analyzers.fs
+++ b/src/CSharpLanguageServer/Roslyn/Analyzers.fs
@@ -1,28 +1,61 @@
 module CSharpLanguageServer.Roslyn.Analyzers
 
+open System
+open System.Collections.Concurrent
 open System.Collections.Immutable
+open System.Runtime.CompilerServices
 open System.Threading
+open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Diagnostics
+
+type private SolutionAnalysisCache = ConcurrentDictionary<ProjectId, Lazy<Task<ImmutableArray<Diagnostic>>>>
+
+let private solutionAnalysisCaches =
+    ConditionalWeakTable<Solution, SolutionAnalysisCache>()
+
+let private projectAnalyzers (project: Project) =
+    project.AnalyzerReferences
+    |> Seq.collect _.GetAnalyzers(LanguageNames.CSharp)
+    |> ImmutableArray.CreateRange
+
+let private getSharedProjectAnalysis
+    (project: Project)
+    (compilation: Compilation)
+    (analyzers: ImmutableArray<DiagnosticAnalyzer>)
+    : Async<ImmutableArray<Diagnostic>> =
+    async {
+        let solutionCache =
+            solutionAnalysisCaches.GetValue(project.Solution, fun _ -> SolutionAnalysisCache())
+
+        let analysisTask =
+            solutionCache
+                .GetOrAdd(
+                    project.Id,
+                    fun _ ->
+                        lazy
+                            // Cancellation applies to each waiter, not to the shared analysis.
+                            let cwa = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions)
+                            cwa.GetAllDiagnosticsAsync(CancellationToken.None)
+                )
+                .Value
+
+        let! ct = Async.CancellationToken
+        return! analysisTask.WaitAsync(ct) |> Async.AwaitTask
+    }
 
 /// Returns compiler diagnostics + all analyzer diagnostics for an entire compilation.
 /// Falls back to compiler-only if the project has no analyzer references.
 let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Compilation) : Async<Diagnostic list> = async {
     let! ct = Async.CancellationToken
 
-    let analyzers =
-        project.AnalyzerReferences
-        |> Seq.collect _.GetAnalyzers(LanguageNames.CSharp)
-        |> ImmutableArray.CreateRange
+    let analyzers = projectAnalyzers project
 
     if analyzers.IsEmpty then
         return compilation.GetDiagnostics(ct) |> List.ofSeq
     else
-        // project.AnalyzerOptions is provided by MSBuildWorkspace and already contains
-        // the AnalyzerConfigOptionsProvider that reads .editorconfig severity rules.
-        let cwa = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions)
-        let! allDiags = cwa.GetAllDiagnosticsAsync(ct) |> Async.AwaitTask
+        let! allDiags = getSharedProjectAnalysis project compilation analyzers
         return allDiags |> List.ofSeq
 }
 
@@ -36,20 +69,12 @@ let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Comp
 let getDocumentDiagnosticsWithAnalyzers (project: Project) (semanticModel: SemanticModel) : Async<Diagnostic list> = async {
     let! ct = Async.CancellationToken
 
-    let analyzers =
-        project.AnalyzerReferences
-        |> Seq.collect _.GetAnalyzers(LanguageNames.CSharp)
-        |> ImmutableArray.CreateRange
+    let analyzers = projectAnalyzers project
 
     if analyzers.IsEmpty then
         return semanticModel.GetDiagnostics(cancellationToken = ct) |> List.ofSeq
     else
-        // project.AnalyzerOptions is provided by MSBuildWorkspace and already contains
-        // the AnalyzerConfigOptionsProvider that reads .editorconfig severity rules.
-        let cwa =
-            semanticModel.Compilation.WithAnalyzers(analyzers, project.AnalyzerOptions)
-
-        let! allDiags = cwa.GetAllDiagnosticsAsync(ct) |> Async.AwaitTask
+        let! allDiags = getSharedProjectAnalysis project semanticModel.Compilation analyzers
 
         // Filter to only diagnostics whose source location is within this document.
         // Diagnostics with no source location (e.g. compilation-level errors) are excluded

--- a/src/CSharpLanguageServer/Roslyn/Analyzers.fs
+++ b/src/CSharpLanguageServer/Roslyn/Analyzers.fs
@@ -1,45 +1,72 @@
 module CSharpLanguageServer.Roslyn.Analyzers
 
+open System
+open System.Collections.Concurrent
 open System.Collections.Immutable
+open System.Runtime.CompilerServices
 open System.Threading
+open System.Threading.Tasks
 
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.Diagnostics
+
+type private SolutionAnalysisCache = ConcurrentDictionary<ProjectId, Lazy<Task<ImmutableArray<Diagnostic>>>>
+
+let private solutionAnalysisCaches =
+    ConditionalWeakTable<Solution, SolutionAnalysisCache>()
+
+let private projectAnalyzers (project: Project) =
+    project.AnalyzerReferences
+    |> Seq.collect _.GetAnalyzers(LanguageNames.CSharp)
+    |> ImmutableArray.CreateRange
+
+let private getSharedProjectAnalysis
+    (project: Project)
+    (compilation: Compilation)
+    (analyzers: ImmutableArray<DiagnosticAnalyzer>)
+    : Async<ImmutableArray<Diagnostic>> =
+    async {
+        let solutionCache =
+            solutionAnalysisCaches.GetValue(project.Solution, fun _ -> SolutionAnalysisCache())
+
+        let analysisTask =
+            solutionCache
+                .GetOrAdd(
+                    project.Id,
+                    fun _ ->
+                        lazy
+                            // Cancellation applies to each waiter, not to the shared analysis.
+                            // MSBuildWorkspace supplies the .editorconfig-aware analyzer options.
+                            // Keep per-project parallelism; workspace diagnostics process projects
+                            // sequentially to avoid starving interactive requests.
+                            let analysisOptions =
+                                CompilationWithAnalyzersOptions(
+                                    options = project.AnalyzerOptions,
+                                    onAnalyzerException = null,
+                                    concurrentAnalysis = true,
+                                    logAnalyzerExecutionTime = false
+                                )
+
+                            let cwa = compilation.WithAnalyzers(analyzers, analysisOptions)
+                            cwa.GetAllDiagnosticsAsync(CancellationToken.None)
+                )
+                .Value
+
+        let! ct = Async.CancellationToken
+        return! analysisTask.WaitAsync(ct) |> Async.AwaitTask
+    }
 
 /// Returns compiler diagnostics + all analyzer diagnostics for an entire compilation.
 /// Falls back to compiler-only if the project has no analyzer references.
 let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Compilation) : Async<Diagnostic list> = async {
     let! ct = Async.CancellationToken
 
-    let analyzers =
-        project.AnalyzerReferences
-        |> Seq.collect _.GetAnalyzers(LanguageNames.CSharp)
-        |> ImmutableArray.CreateRange
+    let analyzers = projectAnalyzers project
 
     if analyzers.IsEmpty then
         return compilation.GetDiagnostics(ct) |> List.ofSeq
     else
-        // project.AnalyzerOptions is provided by MSBuildWorkspace and already contains
-        // the AnalyzerConfigOptionsProvider that reads .editorconfig severity rules.
-        //
-        // concurrentAnalysis is left enabled. Only one project is ever being analyzed
-        // at a time (getWorkspaceDiagnosticReports processes projects sequentially),
-        // so letting a single project's own analyzer pass use every core is safe —
-        // there's no second project's pass competing for the same cores concurrently.
-        // Confirmed against a real multi-project session with analyzers enabled:
-        // interactive requests (completion, hover, ...) stayed responsive throughout
-        // a full workspace/diagnostic sweep. See "Post-implementation notes (Option
-        // C)" in plans/interactive-request-latency-vs-analyzers.md.
-        let analysisOptions =
-            CompilationWithAnalyzersOptions(
-                options = project.AnalyzerOptions,
-                onAnalyzerException = null,
-                concurrentAnalysis = true,
-                logAnalyzerExecutionTime = false
-            )
-
-        let cwa = compilation.WithAnalyzers(analyzers, analysisOptions)
-        let! allDiags = cwa.GetAllDiagnosticsAsync(ct) |> Async.AwaitTask
+        let! allDiags = getSharedProjectAnalysis project compilation analyzers
         return allDiags |> List.ofSeq
 }
 
@@ -53,30 +80,12 @@ let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Comp
 let getDocumentDiagnosticsWithAnalyzers (project: Project) (semanticModel: SemanticModel) : Async<Diagnostic list> = async {
     let! ct = Async.CancellationToken
 
-    let analyzers =
-        project.AnalyzerReferences
-        |> Seq.collect _.GetAnalyzers(LanguageNames.CSharp)
-        |> ImmutableArray.CreateRange
+    let analyzers = projectAnalyzers project
 
     if analyzers.IsEmpty then
         return semanticModel.GetDiagnostics(cancellationToken = ct) |> List.ofSeq
     else
-        // project.AnalyzerOptions is provided by MSBuildWorkspace and already contains
-        // the AnalyzerConfigOptionsProvider that reads .editorconfig severity rules.
-        //
-        // concurrentAnalysis is left enabled — see the comment in
-        // getCompilationDiagnosticsWithAnalyzers above for the rationale.
-        let analysisOptions =
-            CompilationWithAnalyzersOptions(
-                options = project.AnalyzerOptions,
-                onAnalyzerException = null,
-                concurrentAnalysis = true,
-                logAnalyzerExecutionTime = false
-            )
-
-        let cwa = semanticModel.Compilation.WithAnalyzers(analyzers, analysisOptions)
-
-        let! allDiags = cwa.GetAllDiagnosticsAsync(ct) |> Async.AwaitTask
+        let! allDiags = getSharedProjectAnalysis project semanticModel.Compilation analyzers
 
         // Filter to only diagnostics whose source location is within this document.
         // Diagnostics with no source location (e.g. compilation-level errors) are excluded

--- a/src/CSharpLanguageServer/Roslyn/Analyzers.fs
+++ b/src/CSharpLanguageServer/Roslyn/Analyzers.fs
@@ -12,8 +12,17 @@ open Microsoft.CodeAnalysis.Diagnostics
 
 type private SolutionAnalysisCache = ConcurrentDictionary<ProjectId, Lazy<Task<ImmutableArray<Diagnostic>>>>
 
-let private solutionAnalysisCaches =
-    ConditionalWeakTable<Solution, SolutionAnalysisCache>()
+/// Keyed by Solution snapshot; an edited snapshot misses.
+type AnalyzerDiagnosticsCache() =
+    let solutionCaches = ConditionalWeakTable<Solution, SolutionAnalysisCache>()
+
+    member _.GetOrStartAnalysis
+        (solution: Solution, projectId: ProjectId, startAnalysis: unit -> Task<ImmutableArray<Diagnostic>>)
+        : Task<ImmutableArray<Diagnostic>> =
+        solutionCaches
+            .GetValue(solution, fun _ -> SolutionAnalysisCache())
+            .GetOrAdd(projectId, fun _ -> lazy (startAnalysis ()))
+            .Value
 
 let private projectAnalyzers (project: Project) =
     project.AnalyzerReferences
@@ -21,36 +30,32 @@ let private projectAnalyzers (project: Project) =
     |> ImmutableArray.CreateRange
 
 let private getSharedProjectAnalysis
+    (cache: AnalyzerDiagnosticsCache)
     (project: Project)
     (compilation: Compilation)
     (analyzers: ImmutableArray<DiagnosticAnalyzer>)
     : Async<ImmutableArray<Diagnostic>> =
     async {
-        let solutionCache =
-            solutionAnalysisCaches.GetValue(project.Solution, fun _ -> SolutionAnalysisCache())
-
         let analysisTask =
-            solutionCache
-                .GetOrAdd(
-                    project.Id,
-                    fun _ ->
-                        lazy
-                            // Cancellation applies to each waiter, not to the shared analysis.
-                            // MSBuildWorkspace supplies the .editorconfig-aware analyzer options.
-                            // Keep per-project parallelism; workspace diagnostics process projects
-                            // sequentially to avoid starving interactive requests.
-                            let analysisOptions =
-                                CompilationWithAnalyzersOptions(
-                                    options = project.AnalyzerOptions,
-                                    onAnalyzerException = null,
-                                    concurrentAnalysis = true,
-                                    logAnalyzerExecutionTime = false
-                                )
+            cache.GetOrStartAnalysis(
+                project.Solution,
+                project.Id,
+                fun () ->
+                    // Cancellation applies to each waiter, not to the shared analysis.
+                    // MSBuildWorkspace supplies the .editorconfig-aware analyzer options.
+                    // Keep per-project parallelism; workspace diagnostics process projects
+                    // sequentially to avoid starving interactive requests.
+                    let analysisOptions =
+                        CompilationWithAnalyzersOptions(
+                            options = project.AnalyzerOptions,
+                            onAnalyzerException = null,
+                            concurrentAnalysis = true,
+                            logAnalyzerExecutionTime = false
+                        )
 
-                            let cwa = compilation.WithAnalyzers(analyzers, analysisOptions)
-                            cwa.GetAllDiagnosticsAsync(CancellationToken.None)
-                )
-                .Value
+                    let cwa = compilation.WithAnalyzers(analyzers, analysisOptions)
+                    cwa.GetAllDiagnosticsAsync(CancellationToken.None)
+            )
 
         let! ct = Async.CancellationToken
         return! analysisTask.WaitAsync(ct) |> Async.AwaitTask
@@ -58,17 +63,22 @@ let private getSharedProjectAnalysis
 
 /// Returns compiler diagnostics + all analyzer diagnostics for an entire compilation.
 /// Falls back to compiler-only if the project has no analyzer references.
-let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Compilation) : Async<Diagnostic list> = async {
-    let! ct = Async.CancellationToken
+let getCompilationDiagnosticsWithAnalyzers
+    (cache: AnalyzerDiagnosticsCache)
+    (project: Project)
+    (compilation: Compilation)
+    : Async<Diagnostic list> =
+    async {
+        let! ct = Async.CancellationToken
 
-    let analyzers = projectAnalyzers project
+        let analyzers = projectAnalyzers project
 
-    if analyzers.IsEmpty then
-        return compilation.GetDiagnostics(ct) |> List.ofSeq
-    else
-        let! allDiags = getSharedProjectAnalysis project compilation analyzers
-        return allDiags |> List.ofSeq
-}
+        if analyzers.IsEmpty then
+            return compilation.GetDiagnostics(ct) |> List.ofSeq
+        else
+            let! allDiags = getSharedProjectAnalysis cache project compilation analyzers
+            return allDiags |> List.ofSeq
+    }
 
 /// Returns compiler diagnostics + analyzer diagnostics for a single document's semantic model.
 /// Falls back to compiler-only if the project has no analyzer references.
@@ -77,22 +87,27 @@ let getCompilationDiagnosticsWithAnalyzers (project: Project) (compilation: Comp
 /// path rather than GetAnalyzerSemanticDiagnosticsAsync, because some IDE analyzers (e.g.
 /// IDE0040 "accessibility modifiers") emit diagnostics whose reported location causes them
 /// to be missed by the span-based semantic filter.
-let getDocumentDiagnosticsWithAnalyzers (project: Project) (semanticModel: SemanticModel) : Async<Diagnostic list> = async {
-    let! ct = Async.CancellationToken
+let getDocumentDiagnosticsWithAnalyzers
+    (cache: AnalyzerDiagnosticsCache)
+    (project: Project)
+    (semanticModel: SemanticModel)
+    : Async<Diagnostic list> =
+    async {
+        let! ct = Async.CancellationToken
 
-    let analyzers = projectAnalyzers project
+        let analyzers = projectAnalyzers project
 
-    if analyzers.IsEmpty then
-        return semanticModel.GetDiagnostics(cancellationToken = ct) |> List.ofSeq
-    else
-        let! allDiags = getSharedProjectAnalysis project semanticModel.Compilation analyzers
+        if analyzers.IsEmpty then
+            return semanticModel.GetDiagnostics(cancellationToken = ct) |> List.ofSeq
+        else
+            let! allDiags = getSharedProjectAnalysis cache project semanticModel.Compilation analyzers
 
-        // Filter to only diagnostics whose source location is within this document.
-        // Diagnostics with no source location (e.g. compilation-level errors) are excluded
-        // so they aren't duplicated across every open document.
-        let mappedPathMatchesDocFilePath (d: Diagnostic) =
-            let path = d.Location.GetMappedLineSpan().Path
-            path = semanticModel.SyntaxTree.FilePath
+            // Filter to only diagnostics whose source location is within this document.
+            // Diagnostics with no source location (e.g. compilation-level errors) are excluded
+            // so they aren't duplicated across every open document.
+            let mappedPathMatchesDocFilePath (d: Diagnostic) =
+                let path = d.Location.GetMappedLineSpan().Path
+                path = semanticModel.SyntaxTree.FilePath
 
-        return allDiags |> Seq.filter mappedPathMatchesDocFilePath |> List.ofSeq
-}
+            return allDiags |> Seq.filter mappedPathMatchesDocFilePath |> List.ofSeq
+    }

--- a/src/CSharpLanguageServer/Runtime/PushDiagnostics.fs
+++ b/src/CSharpLanguageServer/Runtime/PushDiagnostics.fs
@@ -131,7 +131,7 @@ let processPendingPushDiagnostics
 
                             let! allDiags =
                                 if analyzersEnabled then
-                                    getDocumentDiagnosticsWithAnalyzers doc.Project semanticModel
+                                    getDocumentDiagnosticsWithAnalyzers wf.AnalyzerDiagnostics doc.Project semanticModel
                                 else
                                     async {
                                         let diags = semanticModel.GetDiagnostics(cancellationToken = ct)

--- a/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
+++ b/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
@@ -81,6 +81,8 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
     let workspace, project, firstDocumentId, secondDocumentId = analyzerProject analyzer
     use _workspace = workspace
 
+    let cache = AnalyzerDiagnosticsCache()
+
     // Obtain independent Project wrappers from the same immutable Solution snapshot,
     // as separate document diagnostic requests do in the server.
     let firstProject =
@@ -93,14 +95,14 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
     let secondSemanticModel = getSemanticModel secondProject secondDocumentId
 
     let firstRequest =
-        getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+        getDocumentDiagnosticsWithAnalyzers cache firstProject firstSemanticModel
         |> fun work -> Async.StartAsTask(work, cancellationToken = requestCancellation.Token)
 
     try
         Assert.That(analyzerStarted.Wait(TimeSpan.FromSeconds(10.0)), Is.True, "Analyzer did not start")
 
         let secondRequest =
-            getDocumentDiagnosticsWithAnalyzers secondProject secondSemanticModel
+            getDocumentDiagnosticsWithAnalyzers cache secondProject secondSemanticModel
             |> Async.StartAsTask
 
         requestCancellation.Cancel()
@@ -116,7 +118,7 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
         Assert.That(analyzer.InvocationCount, Is.EqualTo(2), "Expected one analyzer pass over the two syntax trees")
 
         let cachedFirstDiagnostics =
-            getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+            getDocumentDiagnosticsWithAnalyzers cache firstProject firstSemanticModel
             |> Async.RunSynchronously
 
         Assert.That(cachedFirstDiagnostics |> List.map _.Id, Is.EqualTo([ "TEST0001" ]))
@@ -132,7 +134,7 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
         let updatedSemanticModel = getSemanticModel updatedProject firstDocumentId
 
         let updatedDiagnostics =
-            getDocumentDiagnosticsWithAnalyzers updatedProject updatedSemanticModel
+            getDocumentDiagnosticsWithAnalyzers cache updatedProject updatedSemanticModel
             |> Async.RunSynchronously
 
         Assert.That(updatedDiagnostics |> List.exists (fun diagnostic -> diagnostic.Id = "TEST0001"), Is.True)

--- a/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
+++ b/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
@@ -1,13 +1,144 @@
 module CSharpLanguageServer.Tests.AnalyzerTests
 
 open System
+open System.Collections.Immutable
 open System.IO
 open System.Threading
 
 open NUnit.Framework
 open Ionide.LanguageServerProtocol.Types
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Diagnostics
+open Microsoft.CodeAnalysis.Text
 
+open CSharpLanguageServer.Roslyn.Analyzers
 open CSharpLanguageServer.Tests.Tooling
+
+let private analyzerDescriptor =
+    DiagnosticDescriptor(
+        "TEST0001",
+        "Test analyzer",
+        "Test analyzer diagnostic",
+        "Test",
+        DiagnosticSeverity.Warning,
+        true
+    )
+
+type private BlockingCountingAnalyzer(started: ManualResetEventSlim, release: ManualResetEventSlim) =
+    inherit DiagnosticAnalyzer()
+
+    let mutable invocationCount = 0
+
+    member _.InvocationCount = Volatile.Read(&invocationCount)
+
+    override _.SupportedDiagnostics = ImmutableArray.Create(analyzerDescriptor)
+
+    override _.Initialize(context: AnalysisContext) =
+        context.RegisterSyntaxTreeAction(fun context ->
+            Interlocked.Increment(&invocationCount) |> ignore
+            started.Set()
+            release.Wait()
+
+            let location = Location.Create(context.Tree, TextSpan(0, 0))
+            context.ReportDiagnostic(Microsoft.CodeAnalysis.Diagnostic.Create(analyzerDescriptor, location)))
+
+let private analyzerProject (analyzer: DiagnosticAnalyzer) =
+    let analyzerReference =
+        AnalyzerImageReference(ImmutableArray.Create(analyzer), "test-analyzers", "test-analyzers")
+
+    let workspace = new AdhocWorkspace()
+
+    let project =
+        workspace
+            .AddProject("AnalyzerCacheTests", LanguageNames.CSharp)
+            .AddMetadataReference(MetadataReference.CreateFromFile(typeof<obj>.Assembly.Location))
+            .AddAnalyzerReference(analyzerReference)
+
+    let firstDocumentId = DocumentId.CreateNewId(project.Id)
+    let secondDocumentId = DocumentId.CreateNewId(project.Id)
+
+    let project =
+        project.Solution
+            .AddDocument(firstDocumentId, "First.cs", SourceText.From("class First {}"), filePath = "/src/First.cs")
+            .AddDocument(secondDocumentId, "Second.cs", SourceText.From("class Second {}"), filePath = "/src/Second.cs")
+            .GetProject(project.Id)
+        |> Option.ofObj
+        |> Option.get
+
+    workspace, project, firstDocumentId, secondDocumentId
+
+let private getSemanticModel (project: Project) (documentId: DocumentId) =
+    let document = project.GetDocument(documentId) |> Option.ofObj |> Option.get
+    document.GetSemanticModelAsync().Result |> Option.ofObj |> Option.get
+
+[<Test>]
+let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () =
+    use analyzerStarted = new ManualResetEventSlim()
+    use releaseAnalyzer = new ManualResetEventSlim()
+    use requestCancellation = new CancellationTokenSource()
+
+    let analyzer = BlockingCountingAnalyzer(analyzerStarted, releaseAnalyzer)
+    let workspace, project, firstDocumentId, secondDocumentId = analyzerProject analyzer
+    use _workspace = workspace
+
+    // Obtain independent Project wrappers from the same immutable Solution snapshot,
+    // as separate document diagnostic requests do in the server.
+    let firstProject =
+        project.Solution.GetProject(project.Id) |> Option.ofObj |> Option.get
+
+    let secondProject =
+        project.Solution.GetProject(project.Id) |> Option.ofObj |> Option.get
+
+    let firstSemanticModel = getSemanticModel firstProject firstDocumentId
+    let secondSemanticModel = getSemanticModel secondProject secondDocumentId
+
+    let firstRequest =
+        getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+        |> fun work -> Async.StartAsTask(work, cancellationToken = requestCancellation.Token)
+
+    try
+        Assert.That(analyzerStarted.Wait(TimeSpan.FromSeconds(10.0)), Is.True, "Analyzer did not start")
+
+        let secondRequest =
+            getDocumentDiagnosticsWithAnalyzers secondProject secondSemanticModel
+            |> Async.StartAsTask
+
+        requestCancellation.Cancel()
+
+        Assert.Catch<OperationCanceledException>(fun () -> firstRequest.GetAwaiter().GetResult() |> ignore)
+        |> ignore
+
+        releaseAnalyzer.Set()
+
+        let secondDiagnostics = secondRequest.GetAwaiter().GetResult()
+
+        Assert.That(secondDiagnostics |> List.map _.Id, Is.EqualTo([ "TEST0001" ]))
+        Assert.That(analyzer.InvocationCount, Is.EqualTo(2), "Expected one analyzer pass over the two syntax trees")
+
+        let cachedFirstDiagnostics =
+            getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+            |> Async.RunSynchronously
+
+        Assert.That(cachedFirstDiagnostics |> List.map _.Id, Is.EqualTo([ "TEST0001" ]))
+        Assert.That(analyzer.InvocationCount, Is.EqualTo(2), "Expected the completed project analysis to be reused")
+
+        let updatedProject =
+            project.Solution
+                .WithDocumentText(firstDocumentId, SourceText.From("class First { int Value; }"))
+                .GetProject(project.Id)
+            |> Option.ofObj
+            |> Option.get
+
+        let updatedSemanticModel = getSemanticModel updatedProject firstDocumentId
+
+        let updatedDiagnostics =
+            getDocumentDiagnosticsWithAnalyzers updatedProject updatedSemanticModel
+            |> Async.RunSynchronously
+
+        Assert.That(updatedDiagnostics |> List.exists (fun diagnostic -> diagnostic.Id = "TEST0001"), Is.True)
+        Assert.That(analyzer.InvocationCount, Is.EqualTo(4), "Expected a changed project snapshot to be reanalyzed")
+    finally
+        releaseAnalyzer.Set()
 
 // Client profile with pull diagnostics enabled (both textDocument and workspace)
 // and analyzers explicitly turned on.

--- a/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
+++ b/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
@@ -1,14 +1,145 @@
 module CSharpLanguageServer.Tests.AnalyzerTests
 
 open System
+open System.Collections.Immutable
 open System.IO
 open System.Threading
 
 open NUnit.Framework
 open Ionide.LanguageServerProtocol.Types
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Diagnostics
+open Microsoft.CodeAnalysis.Text
 
+open CSharpLanguageServer.Roslyn.Analyzers
 open CSharpLanguageServer.Tests.Tooling
 open CSharpLanguageServer.Tests.Fixtures
+
+let private analyzerDescriptor =
+    DiagnosticDescriptor(
+        "TEST0001",
+        "Test analyzer",
+        "Test analyzer diagnostic",
+        "Test",
+        DiagnosticSeverity.Warning,
+        true
+    )
+
+type private BlockingCountingAnalyzer(started: ManualResetEventSlim, release: ManualResetEventSlim) =
+    inherit DiagnosticAnalyzer()
+
+    let mutable invocationCount = 0
+
+    member _.InvocationCount = Volatile.Read(&invocationCount)
+
+    override _.SupportedDiagnostics = ImmutableArray.Create(analyzerDescriptor)
+
+    override _.Initialize(context: AnalysisContext) =
+        context.RegisterSyntaxTreeAction(fun context ->
+            Interlocked.Increment(&invocationCount) |> ignore
+            started.Set()
+            release.Wait()
+
+            let location = Location.Create(context.Tree, TextSpan(0, 0))
+            context.ReportDiagnostic(Microsoft.CodeAnalysis.Diagnostic.Create(analyzerDescriptor, location)))
+
+let private analyzerProject (analyzer: DiagnosticAnalyzer) =
+    let analyzerReference =
+        AnalyzerImageReference(ImmutableArray.Create(analyzer), "test-analyzers", "test-analyzers")
+
+    let workspace = new AdhocWorkspace()
+
+    let project =
+        workspace
+            .AddProject("AnalyzerCacheTests", LanguageNames.CSharp)
+            .AddMetadataReference(MetadataReference.CreateFromFile(typeof<obj>.Assembly.Location))
+            .AddAnalyzerReference(analyzerReference)
+
+    let firstDocumentId = DocumentId.CreateNewId(project.Id)
+    let secondDocumentId = DocumentId.CreateNewId(project.Id)
+
+    let project =
+        project.Solution
+            .AddDocument(firstDocumentId, "First.cs", SourceText.From("class First {}"), filePath = "/src/First.cs")
+            .AddDocument(secondDocumentId, "Second.cs", SourceText.From("class Second {}"), filePath = "/src/Second.cs")
+            .GetProject(project.Id)
+        |> Option.ofObj
+        |> Option.get
+
+    workspace, project, firstDocumentId, secondDocumentId
+
+let private getSemanticModel (project: Project) (documentId: DocumentId) =
+    let document = project.GetDocument(documentId) |> Option.ofObj |> Option.get
+    document.GetSemanticModelAsync().Result |> Option.ofObj |> Option.get
+
+[<Test>]
+let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () =
+    use analyzerStarted = new ManualResetEventSlim()
+    use releaseAnalyzer = new ManualResetEventSlim()
+    use requestCancellation = new CancellationTokenSource()
+
+    let analyzer = BlockingCountingAnalyzer(analyzerStarted, releaseAnalyzer)
+    let workspace, project, firstDocumentId, secondDocumentId = analyzerProject analyzer
+    use _workspace = workspace
+
+    // Obtain independent Project wrappers from the same immutable Solution snapshot,
+    // as separate document diagnostic requests do in the server.
+    let firstProject =
+        project.Solution.GetProject(project.Id) |> Option.ofObj |> Option.get
+
+    let secondProject =
+        project.Solution.GetProject(project.Id) |> Option.ofObj |> Option.get
+
+    let firstSemanticModel = getSemanticModel firstProject firstDocumentId
+    let secondSemanticModel = getSemanticModel secondProject secondDocumentId
+
+    let firstRequest =
+        getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+        |> fun work -> Async.StartAsTask(work, cancellationToken = requestCancellation.Token)
+
+    try
+        Assert.That(analyzerStarted.Wait(TimeSpan.FromSeconds(10.0)), Is.True, "Analyzer did not start")
+
+        let secondRequest =
+            getDocumentDiagnosticsWithAnalyzers secondProject secondSemanticModel
+            |> Async.StartAsTask
+
+        requestCancellation.Cancel()
+
+        Assert.Catch<OperationCanceledException>(Action(fun () -> firstRequest.GetAwaiter().GetResult() |> ignore))
+        |> ignore
+
+        releaseAnalyzer.Set()
+
+        let secondDiagnostics = secondRequest.GetAwaiter().GetResult()
+
+        Assert.That(secondDiagnostics |> List.map _.Id, Is.EqualTo<string list>([ "TEST0001" ]))
+        Assert.That(analyzer.InvocationCount, Is.EqualTo(2), "Expected one analyzer pass over the two syntax trees")
+
+        let cachedFirstDiagnostics =
+            getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+            |> Async.RunSynchronously
+
+        Assert.That(cachedFirstDiagnostics |> List.map _.Id, Is.EqualTo<string list>([ "TEST0001" ]))
+        Assert.That(analyzer.InvocationCount, Is.EqualTo(2), "Expected the completed project analysis to be reused")
+
+        let updatedProject =
+            project.Solution
+                .WithDocumentText(firstDocumentId, SourceText.From("class First { int Value; }"))
+                .GetProject(project.Id)
+            |> Option.ofObj
+            |> Option.get
+
+        let updatedSemanticModel = getSemanticModel updatedProject firstDocumentId
+
+        let updatedDiagnostics =
+            getDocumentDiagnosticsWithAnalyzers updatedProject updatedSemanticModel
+            |> Async.RunSynchronously
+
+        Assert.That(updatedDiagnostics |> List.exists (fun diagnostic -> diagnostic.Id = "TEST0001"), Is.True)
+        Assert.That(analyzer.InvocationCount, Is.EqualTo(4), "Expected a changed project snapshot to be reanalyzed")
+    finally
+        releaseAnalyzer.Set()
 
 // Client profile with pull diagnostics enabled (both textDocument and workspace)
 // and analyzers explicitly turned on.

--- a/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
+++ b/tests/CSharpLanguageServer.Tests/AnalyzerTests.fs
@@ -82,6 +82,8 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
     let workspace, project, firstDocumentId, secondDocumentId = analyzerProject analyzer
     use _workspace = workspace
 
+    let cache = AnalyzerDiagnosticsCache()
+
     // Obtain independent Project wrappers from the same immutable Solution snapshot,
     // as separate document diagnostic requests do in the server.
     let firstProject =
@@ -94,14 +96,14 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
     let secondSemanticModel = getSemanticModel secondProject secondDocumentId
 
     let firstRequest =
-        getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+        getDocumentDiagnosticsWithAnalyzers cache firstProject firstSemanticModel
         |> fun work -> Async.StartAsTask(work, cancellationToken = requestCancellation.Token)
 
     try
         Assert.That(analyzerStarted.Wait(TimeSpan.FromSeconds(10.0)), Is.True, "Analyzer did not start")
 
         let secondRequest =
-            getDocumentDiagnosticsWithAnalyzers secondProject secondSemanticModel
+            getDocumentDiagnosticsWithAnalyzers cache secondProject secondSemanticModel
             |> Async.StartAsTask
 
         requestCancellation.Cancel()
@@ -117,7 +119,7 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
         Assert.That(analyzer.InvocationCount, Is.EqualTo(2), "Expected one analyzer pass over the two syntax trees")
 
         let cachedFirstDiagnostics =
-            getDocumentDiagnosticsWithAnalyzers firstProject firstSemanticModel
+            getDocumentDiagnosticsWithAnalyzers cache firstProject firstSemanticModel
             |> Async.RunSynchronously
 
         Assert.That(cachedFirstDiagnostics |> List.map _.Id, Is.EqualTo<string list>([ "TEST0001" ]))
@@ -133,7 +135,7 @@ let testProjectAnalyzerAnalysisIsSharedAcrossDocumentsAndRequestCancellation () 
         let updatedSemanticModel = getSemanticModel updatedProject firstDocumentId
 
         let updatedDiagnostics =
-            getDocumentDiagnosticsWithAnalyzers updatedProject updatedSemanticModel
+            getDocumentDiagnosticsWithAnalyzers cache updatedProject updatedSemanticModel
             |> Async.RunSynchronously
 
         Assert.That(updatedDiagnostics |> List.exists (fun diagnostic -> diagnostic.Id = "TEST0001"), Is.True)

--- a/tests/benchmarks/AnalyzerDiagnostics.fsx
+++ b/tests/benchmarks/AnalyzerDiagnostics.fsx
@@ -1,0 +1,82 @@
+#I "../CSharpLanguageServer.Tests/bin/Debug/net10.0"
+#r "Ionide.LanguageServerProtocol.dll"
+#r "Newtonsoft.Json.dll"
+#r "nunit.framework.dll"
+#r "CSharpLanguageServer.dll"
+#r "CSharpLanguageServer.Tests.dll"
+
+open System
+open System.Diagnostics
+open System.IO
+open Ionide.LanguageServerProtocol.Types
+open CSharpLanguageServer.Tests.Tooling
+
+let profile =
+    { defaultClientProfile with
+        ServerConfig =
+            { defaultClientProfile.ServerConfig with
+                analyzersEnabled = Some true } }
+
+let documentCount = 12
+
+let addDocuments solutionDir =
+    let projectDir = Path.Combine(solutionDir, "Project")
+
+    for index in 1..documentCount do
+        File.WriteAllText(Path.Combine(projectDir, $"Benchmark{index}.cs"), $"class Benchmark{index} {{ int unused; }}")
+
+    let exitCode, stdout, stderr = runDotnetBuild projectDir
+
+    if exitCode <> 0 && exitCode <> 1 then
+        failwith $"Fixture build failed ({exitCode}):\n{stdout}\n{stderr}"
+
+let requestDiagnostics (client: LspTestClient) uri =
+    let parameters: DocumentDiagnosticParams =
+        { WorkDoneToken = None
+          PartialResultToken = None
+          TextDocument = { Uri = uri }
+          Identifier = None
+          PreviousResultId = None }
+
+    match
+        client.Request<DocumentDiagnosticParams, DocumentDiagnosticReport option>("textDocument/diagnostic", parameters)
+    with
+    | Some(U2.C1 report) -> report.Items.Length
+    | _ -> failwith $"Expected full diagnostics for {uri}"
+
+let run () =
+    let outputDirectory =
+        Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "../CSharpLanguageServer.Tests/bin/Debug/net10.0"))
+
+    Directory.SetCurrentDirectory(outputDirectory)
+
+    use client =
+        activateFixtureExt "projectWithEditorConfigAnalyzers" profile addDocuments id
+
+    use openDocument = client.Open("Project/Class.cs")
+    requestDiagnostics client openDocument.Uri |> ignore
+
+    let uris =
+        [| for index in 1..documentCount -> fileUriForProjectDir client.SolutionDir $"Project/Benchmark{index}.cs" |]
+
+    let serverProcess = client.GetState().ServerProcess.Value
+    serverProcess.Refresh()
+    let cpuBefore = serverProcess.TotalProcessorTime
+    let total = Stopwatch.StartNew()
+
+    let results =
+        [| for uri in uris do
+               let request = Stopwatch.StartNew()
+               let diagnosticCount = requestDiagnostics client uri
+               request.Stop()
+               yield int64 request.Elapsed.TotalMilliseconds, diagnosticCount |]
+
+    total.Stop()
+    serverProcess.Refresh()
+
+    printfn "request times (ms): %A" (results |> Array.map fst)
+    printfn "diagnostics per request: %A" (results |> Array.map snd)
+    printfn "wall time: %d ms" (int64 total.Elapsed.TotalMilliseconds)
+    printfn "server CPU time: %d ms" (int64 (serverProcess.TotalProcessorTime - cpuBefore).TotalMilliseconds)
+
+run ()

--- a/tests/benchmarks/AnalyzerDiagnostics.fsx
+++ b/tests/benchmarks/AnalyzerDiagnostics.fsx
@@ -1,0 +1,82 @@
+#I "../CSharpLanguageServer.Tests/bin/Debug/net10.0"
+#r "Ionide.LanguageServerProtocol.dll"
+#r "nunit.framework.dll"
+#r "CSharpLanguageServer.dll"
+#r "CSharpLanguageServer.Tests.dll"
+
+open System
+open System.Diagnostics
+open System.IO
+open Ionide.LanguageServerProtocol.Types
+open CSharpLanguageServer.Tests.Tooling
+open CSharpLanguageServer.Tests.Fixtures
+
+let profile =
+    { defaultClientProfile with
+        ServerConfig =
+            { defaultClientProfile.ServerConfig with
+                analyzersEnabled = Some true } }
+
+let documentCount = 12
+
+let addDocuments solutionDir =
+    let projectDir = Path.Combine(solutionDir, "Project")
+
+    for index in 1..documentCount do
+        File.WriteAllText(Path.Combine(projectDir, $"Benchmark{index}.cs"), $"class Benchmark{index} {{ int unused; }}")
+
+    let exitCode, stdout, stderr = runDotnetBuild projectDir
+
+    if exitCode <> 0 && exitCode <> 1 then
+        failwith $"Fixture build failed ({exitCode}):\n{stdout}\n{stderr}"
+
+let requestDiagnostics (client: LspTestClient) uri =
+    let parameters: DocumentDiagnosticParams =
+        { WorkDoneToken = None
+          PartialResultToken = None
+          TextDocument = { Uri = uri }
+          Identifier = None
+          PreviousResultId = None }
+
+    match
+        client.Request<DocumentDiagnosticParams, DocumentDiagnosticReport option>("textDocument/diagnostic", parameters)
+    with
+    | Some(U2.C1 report) -> report.Items.Length
+    | _ -> failwith $"Expected full diagnostics for {uri}"
+
+let run () =
+    let outputDirectory =
+        Path.GetFullPath(Path.Combine(__SOURCE_DIRECTORY__, "../CSharpLanguageServer.Tests/bin/Debug/net10.0"))
+
+    Directory.SetCurrentDirectory(outputDirectory)
+
+    use client =
+        activateFixtureExt "projectWithEditorConfigAnalyzers" profile addDocuments id
+
+    use openDocument = client.Open("Project/Class.cs")
+    requestDiagnostics client openDocument.Uri |> ignore
+
+    let uris =
+        [| for index in 1..documentCount -> fileUriForProjectDir client.SolutionDir $"Project/Benchmark{index}.cs" |]
+
+    let serverProcess = client.GetState().ServerProcess.Value
+    serverProcess.Refresh()
+    let cpuBefore = serverProcess.TotalProcessorTime
+    let total = Stopwatch.StartNew()
+
+    let results =
+        [| for uri in uris do
+               let request = Stopwatch.StartNew()
+               let diagnosticCount = requestDiagnostics client uri
+               request.Stop()
+               yield int64 request.Elapsed.TotalMilliseconds, diagnosticCount |]
+
+    total.Stop()
+    serverProcess.Refresh()
+
+    printfn "request times (ms): %A" (results |> Array.map fst)
+    printfn "diagnostics per request: %A" (results |> Array.map snd)
+    printfn "wall time: %d ms" (int64 total.Elapsed.TotalMilliseconds)
+    printfn "server CPU time: %d ms" (int64 (serverProcess.TotalProcessorTime - cpuBefore).TotalMilliseconds)
+
+run ()


### PR DESCRIPTION
Fixes #403.

## Diagnosis

Document diagnostics currently create a new `CompilationWithAnalyzers` and run `GetAllDiagnosticsAsync` for every requested document. The result covers the whole project, but each request keeps only diagnostics for its own syntax tree. Pulling several documents from one unchanged solution snapshot therefore repeats the same project-wide analyzer work.

## Change

Cache one lazy analyzer task per project and immutable Roslyn `Solution` snapshot. Document and compilation diagnostics share that result. A new solution snapshot naturally gets a new cache, and the weak solution key allows old snapshots to be collected.

Request cancellation only cancels that request's wait. It does not cancel analyzer work already shared with another document request.

The production change is 43 added lines and 18 removed lines in `Roslyn/Analyzers.fs`.

## User impact

Diagnostic payloads and update behavior do not change. The first analyzer request for a solution snapshot still performs the full analysis. Later document requests for the same snapshot reuse it. Editing any document creates a new snapshot, so the next request analyzes the updated project before reuse begins again.

A real-LSP four-file evaluation covered same-file edits that clear and add IDE diagnostics, saves, unrelated document pulls, cross-file edits that add and clear `CS0103`, workspace pulls, and push diagnostics. Normalized diagnostic payloads matched the baseline in all three fresh sessions.

## Benchmark

`tests/benchmarks/AnalyzerDiagnostics.fsx` starts the real LSP, enables analyzers, warms one document, then pulls diagnostics for 12 other documents in the same project snapshot. It prints the actual request times and diagnostic counts.

```sh
nix develop -c dotnet build tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
nix develop -c dotnet fsi tests/benchmarks/AnalyzerDiagnostics.fsx
```

Upstream main (`e2efc47`), representative run:

```text
request times (ms): [|47L; 42L; 43L; 72L; 44L; 41L; 42L; 42L; 40L; 63L; 42L; 38L|]
diagnostics per request: [|6; 6; 6; 6; 6; 6; 6; 6; 6; 6; 6; 6|]
wall time: 563 ms
server CPU time: 2150 ms
```

This branch (`c2002e0`), representative run:

```text
request times (ms): [|4L; 2L; 2L; 2L; 2L; 2L; 2L; 2L; 2L; 2L; 2L; 2L|]
diagnostics per request: [|6; 6; 6; 6; 6; 6; 6; 6; 6; 6; 6; 6|]
wall time: 27 ms
server CPU time: 40 ms
```

Across three fresh server processes, the median wall time fell from 572 ms to 27 ms. Median server CPU time fell from 2,150 ms to 30 ms. Every sample returned the same 72 diagnostics.

## Verification

```text
Passed: 293, Failed: 0, Skipped: 0
```

The analyzer cache regression test also covers concurrent document requests, request cancellation isolation, completed-result reuse, and invalidation after a document edit.
