### PR TITLE
fix(workspace): only force a TargetFramework every project declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 * Re-enable Razor tests: upgrade Roslyn packages to 5.9.0 (now satisfies .NET SDK 10.0.400's Razor generator requirement) and fix Razor hover/references resolving to the wrong token under Roslyn's newer `#line` directive format
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/408
+* Fix a project with a platform-specific TFM (e.g. `net10.0-windows`) forcing that TFM onto every other project in the solution, breaking package resolution and producing phantom errors; a workspace-global `TargetFramework` is now only applied when every project declares it
+  - Reported in https://github.com/razzmatazz/csharp-language-server/issues/405
 * Fix workspace pull diagnostics returning `unchanged` after source document edits, which could leave clients with stale results
   - Reported in https://github.com/razzmatazz/csharp-language-server/issues/401
 * Fix decompiled metadata navigation stripping trailing characters from type names and failing for nested types; attach loose documents to the nearest containing project in nested-project layouts

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -171,23 +171,19 @@ let loadProjectTfms (projs: string seq) : Async<Map<string, list<string>>> =
 let frameworkIsCompatible a b =
     DefaultCompatibilityProvider.Instance.IsCompatible(a, b)
 
-let compatibleTfmsOfTwoSets afxs bfxs = seq {
-    for a in afxs |> Seq.map NuGetFramework.Parse do
-        for b in bfxs |> Seq.map NuGetFramework.Parse do
-            if frameworkIsCompatible a b then
-                yield a.GetShortFolderName()
-            else if frameworkIsCompatible b a then
-                yield b.GetShortFolderName()
-}
+/// Normalise a declared TFM to its canonical short folder name so that equivalent
+/// spellings intersect correctly.  Returns None for values NuGet cannot make sense of
+/// (GetShortFolderName throws on unsupported frameworks).
+let private tryNormalizeTfm (tfm: string) : string option =
+    try
+        let fx = NuGetFramework.Parse tfm
 
-let compatibleTfmSet (tfmSets: list<Set<string>>) : Set<string> =
-    match tfmSets.Length with
-    | 0 -> Set.empty
-    | 1 -> tfmSets |> List.head
-    | _ ->
-        let firstSet = tfmSets |> List.head
-
-        tfmSets |> List.skip 1 |> Seq.fold compatibleTfmsOfTwoSets firstSet |> Set.ofSeq
+        if fx.IsUnsupported then
+            None
+        else
+            Some(fx.GetShortFolderName())
+    with _ ->
+        None
 
 let bestTfm (tfms: string seq) : string option =
     let frameworks = tfms |> Seq.map NuGetFramework.Parse |> List.ofSeq
@@ -203,15 +199,19 @@ let bestTfm (tfms: string seq) : string option =
         |> _.GetShortFolderName()
         |> Some
 
+/// The TFM to hand to MSBuild as a workspace-global property, or None when no single TFM
+/// is safe for every project.  Only a TFM declared by *every* project qualifies: MSBuild
+/// global properties override each project's own <TargetFramework>, and a project that was
+/// never restored for that TFM has no matching target in its project.assets.json, so its
+/// design-time build fails with NETSDK1005 and loses every package and framework reference.
 let workspaceTargetFramework (tfmsPerProject: Map<string, string list>) : option<string> =
-    match tfmsPerProject.Count with
-    | 0 -> None
-    | _ ->
+    match
         tfmsPerProject.Values
-        |> Seq.map Set.ofSeq
+        |> Seq.map (Seq.choose tryNormalizeTfm >> Set.ofSeq)
         |> List.ofSeq
-        |> compatibleTfmSet
-        |> bestTfm
+    with
+    | [] -> None
+    | first :: rest -> rest |> List.fold Set.intersect first |> bestTfm
 
 let resolveDefaultWorkspaceProps (targetFramework: string option) : Map<string, string> =
     let applyTargetFrameworkProp props =

--- a/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/Project/Class.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/Project/Class.cs
@@ -1,0 +1,11 @@
+using System;
+using Newtonsoft.Json;
+
+class Class
+{
+    public void MethodA(string arg)
+    {
+        string str = JsonConvert.SerializeObject(arg);
+        Console.WriteLine(str);
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/Project/Project.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/Project/Project.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A PackageReference is essential to this regression: framework references come from
+         the targeting pack and survive a failed design-time build, but package references
+         are read from project.assets.json, which has no net10.0-windows target. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+  </ItemGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/Project/Project.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/Project/Project.csproj
@@ -1,6 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <!-- Keep this regression fixture deterministic in CI: its package is already restored
+         by the test project, and vulnerability auditing would add an unrelated network call. -->
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
   <ItemGroup>
     <!-- A PackageReference is essential to this regression: framework references come from

--- a/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/WinApp/WinApp.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/WinApp/WinApp.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-windows</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/WinApp/WinClass.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/WinApp/WinClass.cs
@@ -1,0 +1,3 @@
+class WinClass
+{
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/platformSpecificTfm.sln
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/platformSpecificTfm/platformSpecificTfm.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project", "Project\Project.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinApp", "WinApp\WinApp.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/CSharpLanguageServer.Tests/InitializationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InitializationTests.fs
@@ -182,6 +182,58 @@ let testMultiTargetProjectLoads () =
 
     ClassicAssert.IsTrue(client.ServerMessageLogContains(fun m -> m.Contains "loading project"))
 
+/// Regression test for https://github.com/razzmatazz/csharp-language-server/issues/405:
+/// a solution mixing a plain net10.0 project with a net10.0-windows one used to have the
+/// platform-specific TFM applied as a workspace-global MSBuild property, overriding the
+/// plain project's own TargetFramework.  Its project.assets.json has no net10.0-windows
+/// target, so the design-time build failed with NETSDK1005, dropped every reference, and
+/// the server reported phantom errors on code that compiles cleanly.
+[<Test>]
+let testPlatformSpecificTfmDoesNotBreakSiblingProjects () =
+    // The restore is what makes this test meaningful: it produces a project.assets.json
+    // for Project containing a net10.0 target and nothing else.
+    let prebuild (solutionDir: string) =
+        let exitCode, stdout, stderr = runDotnetBuild solutionDir
+
+        if exitCode <> 0 then
+            failwithf
+                "Pre-build of platformSpecificTfm fixture failed (exit %d):\nstdout:\n%s\nstderr:\n%s"
+                exitCode
+                stdout
+                stderr
+
+    use client =
+        activateFixtureExt "platformSpecificTfm" defaultClientProfile prebuild id
+
+    assertHoverWorks
+        client
+        "Project/Class.cs"
+        { Line = 5u; Character = 17u }
+        "```csharp\nvoid Class.MethodA(string arg)\n```"
+
+    use classFile = client.Open("Project/Class.cs")
+
+    let diagnosticParams: DocumentDiagnosticParams =
+        { WorkDoneToken = None
+          PartialResultToken = None
+          TextDocument = { Uri = classFile.Uri }
+          Identifier = None
+          PreviousResultId = None }
+
+    let report: DocumentDiagnosticReport option =
+        client.Request("textDocument/diagnostic", diagnosticParams)
+
+    match report with
+    | Some(U2.C1 report) ->
+        let errors =
+            report.Items
+            |> Array.filter (fun d -> d.Severity = Some DiagnosticSeverity.Error)
+
+        let errorsStr = errors |> Array.map _.Message |> String.concat "; "
+
+        ClassicAssert.AreEqual(0, errors.Length, $"expected no errors on Project/Class.cs, got: {errorsStr}")
+    | _ -> failwith "U2.C1 (full report) was expected"
+
 [<Test>]
 let testMultiTargetWorkspace () =
     let clientWorkspaceCaps: WorkspaceClientCapabilities =

--- a/tests/CSharpLanguageServer.Tests/InternalTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InternalTests.fs
@@ -16,11 +16,16 @@ open CSharpLanguageServer.Roslyn.Solution
 [<TestCase("1.csproj:net40,net462,net6.0,net8.0,net8.0-windows,netcoreapp3.1,netstandard2.0", "net8.0-windows")>]
 [<TestCase("1.csproj:net40,net462", "net462")>]
 [<TestCase("1.csproj:net8.0 2.csproj:net8.0", "net8.0")>]
-[<TestCase("1.csproj:net8.0,net10.0 2.csproj:netstandard2.0,net462", "net10.0")>]
+[<TestCase("1.csproj:net8.0,net10.0 2.csproj:netstandard2.0,net462", null)>]
 [<TestCase("1.csproj:net8.0,net10.0 2.csproj:net8.0,net10.0", "net10.0")>]
-[<TestCase("1.csproj:net8.0 2.csproj:net8.0,net10.0", "net10.0")>]
-[<TestCase("1.csproj:net8.0 2.csproj:net9.0-windows", "net9.0-windows")>]
-[<TestCase("1.csproj:net9.0 2.csproj:net9.0-windows", "net9.0-windows")>]
+[<TestCase("1.csproj:net8.0 2.csproj:net8.0,net10.0", "net8.0")>]
+// A TFM that only some projects declare must never become a workspace-global MSBuild
+// property: it would override the other projects' own TargetFramework and invalidate
+// their restore output.  See https://github.com/razzmatazz/csharp-language-server/issues/405
+[<TestCase("1.csproj:net8.0 2.csproj:net9.0-windows", null)>]
+[<TestCase("1.csproj:net9.0 2.csproj:net9.0-windows", null)>]
+[<TestCase("1.csproj:net10.0 2.csproj:net10.0-windows", null)>]
+[<TestCase("1.csproj:net10.0,net10.0-windows 2.csproj:net10.0", "net10.0")>]
 let testApplyWorkspaceTargetFrameworkProp (tfmList: string, expectedTfm: string | null) =
 
     let parseTfmList (projectEntry: string) : string * list<string> =


### PR DESCRIPTION
Fixes #405.

## Problem

In a solution where one project targets a platform-specific TFM (e.g. `net10.0-windows`) and another targets plain `net10.0`, the language server reports phantom errors (`CS0246`/`CS1061`) in the plain project on code that `dotnet build` compiles with 0 errors.

Repro provided by the reporter: https://github.com/ErnieBernie10/csharp-ls-windows-tfm-repro

## Root cause

`workspaceTargetFramework` collapsed every project's TFMs into one value via `compatibleTfmSet` → `DefaultCompatibilityProvider.IsCompatible`. That relation is asymmetric — a project targeting `net10.0-windows` can consume `net10.0` libraries — so the platform-specific TFM always won, and `bestTfm` reinforced it by ranking on `fx.HasPlatform`.

That single TFM was then passed to `MSBuildWorkspace.Create` as a **global** MSBuild property, which overrides each project's own `<TargetFramework>`. A project restored for plain `net10.0` has no `net10.0-windows` target in its `project.assets.json`:

```
error NETSDK1005: Assets file 'obj/project.assets.json' doesn't have a target for 'net10.0-windows'.
```

so its design-time build fails and it loses every package reference. Roslyn binds an incomplete compilation and reports errors. `dotnet build` is unaffected because it never sees that global property.

This was the intended behaviour rather than a regression — it was pinned by `InternalTests.fs` (`net9.0` + `net9.0-windows` → `net9.0-windows`).

## Fix

Pick the TFM from the **intersection** of the declared TFM sets, so a workspace-global `TargetFramework` is only applied when every project declares it; otherwise no `TargetFramework` property is passed and each project is evaluated on its own. Roslyn already loads one project per TFM for multi-targeted projects, so nothing is lost when the intersection is empty.

| Declared TFMs | before | after |
|---|---|---|
| `A:{net10.0}` `B:{net10.0-windows}` | `net10.0-windows` | none |
| `A:{net8.0}` `B:{net8.0,net10.0}` | `net10.0` | `net8.0` |
| `A:{net6.0,net8.0}` (single project) | `net8.0` | `net8.0` |
| `A:{net8.0,net10.0}` `B:{netstandard2.0,net462}` | `net10.0` | none |

`compatibleTfmsOfTwoSets` and `compatibleTfmSet` are removed as unused; `bestTfm` still ranks the common candidates and is unchanged. A small `tryNormalizeTfm` helper canonicalises TFM spellings before intersecting and drops values NuGet cannot parse (`GetShortFolderName` throws on unsupported frameworks).

## Tests

- `InternalTests.fs`: four multi-project expectations updated to the new semantics, plus cases pinning this issue.
- New `platformSpecificTfm` fixture (`net10.0` + `net10.0-windows` + sln) and `testPlatformSpecificTfmDoesNotBreakSiblingProjects` in `InitializationTests.fs`. The fixture is pre-built via the existing `runDotnetBuild` helper so the restore produces a `net10.0`-only assets file, and the `net10.0` project carries a `PackageReference` — that part is essential, since framework references come from the targeting pack and survive the failed design-time build while package references do not.

Without the fix the new test fails with exactly the reported symptom:

```
expected no errors on Project/Class.cs, got: The type or namespace name 'Newtonsoft' could not be
found (are you missing a using directive or an assembly reference?); The name 'JsonConvert' does
not exist in the current context
```

Full suite: 296/296 passing locally. Also verified against the reporter's repro repository — `Will use MSBuild props: map [(TargetFramework, net10.0-windows)]` before, `map []` after.

## Note on CI

Unrelated to this change: on .NET SDK 10.0.3xx, `Microsoft.FSharp.NetSdk.props` sets `DisableImplicitFSharpCoreReference=true` whenever `ManagePackageVersionsCentrally` is true. `Ionide.LanguageServerProtocol` then compiles against the compiler's bundled FSharp.Core 10.1.0.0 while `CSharpLanguageServer` still resolves 10.0.101 transitively through `FSharp.Control.AsyncSeq`, and the build fails with `MSB3277`. I hit this locally and worked around it with a patched `Directory.Packages.props`; if CI runs on such an SDK it will fail here for that reason, not because of this change. Happy to send a separate PR for it.
