### PR TITLE
Fix references/incomingCalls leaking a dynamic assembly per request

### DIFF
--- a/src/CSharpLanguageServer/Roslyn/WorkspaceServices.fs
+++ b/src/CSharpLanguageServer/Roslyn/WorkspaceServices.fs
@@ -300,6 +300,11 @@ type RemoteHostClientProviderInterceptor(_logMessage) =
 
 
 type WorkspaceServicesInterceptor() =
+    // A ProxyGenerator caches generated proxy *types* per instance; creating a
+    // fresh generator on every intercepted GetService call defeats that cache
+    // and emits a new (uncollectible) dynamic assembly per call.
+    static let generator = ProxyGenerator()
+
     let logger = Logging.getLoggerByName "WorkspaceServicesInterceptor"
 
     interface IInterceptor with
@@ -309,7 +314,6 @@ type WorkspaceServicesInterceptor() =
             if invocation.Method.Name = "GetService" && invocation.ReturnValue = null then
                 let updatedReturnValue =
                     let serviceType = invocation.GenericArguments[0]
-                    let generator = ProxyGenerator()
 
                     match serviceType.FullName with
                     | "Microsoft.CodeAnalysis.Options.ILegacyGlobalOptionsWorkspaceService" ->


### PR DESCRIPTION
While load-testing csharp-ls 0.24.0 against my production C# monorepo I found
that `textDocument/references` and `callHierarchy/incomingCalls` leak memory
and OS handles on every single request. Nothing is ever released until the
process exits. Hover and definition stay flat under the same load, so I
chased it down to root cause. The fix is a one-liner.

`WorkspaceServicesInterceptor.Intercept` creates a fresh `ProxyGenerator` for
every `GetService` call that returns null. Castle caches generated proxy
types per `ProxyGenerator` instance, so a new generator per call emits a new
dynamic assembly every time, and assemblies are never collected (the
[Castle docs](https://github.com/castleproject/Core/blob/master/docs/dynamicproxy.md)
call this usage out as a leak). Roslyn's FindReferences machinery requests
one of the intercepted services on every call: `dotnet-counters` shows the
server loading ~1,000 assemblies per second under references load
(158,912 -> 177,085 in 18 seconds), each one permanently pinning its
metadata, loader heaps and a pair of loader sync handles. On my monorepo
that comes out to ~10.7 MB per references request. Hover and definition
never hit a null `GetService`, which is why they stay clean.

This PR hoists the generator to `static let`, the same pattern
`CleanCodeGenOptionsProxy` in the same file already uses. The interceptor is
identical on current `main`; I run 0.24.0 in production, so the measurements
below are from that tag, references-only load, 12 requests in flight, same
machine, only this one line different:

- per-call generator: 613 req/s and decaying, +4.7 GB/min, assembly count unbounded
- static generator: 10,514 req/s flat, ~1.2 KB/request (the same floor as hover), assembly count stable

The assembly emission was not just the leak, it was also the throughput
ceiling: the fixed build serves 26x more references requests in the same
window.
