### PR TITLE
Implement callHierarchy/outgoingCalls

### DIFF
--- a/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
+++ b/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
@@ -148,8 +148,8 @@ module CallHierarchy =
                 | Some(symbol, _, _) when isCallableSymbol symbol ->
                     // SymbolFinder has no outgoing counterpart to FindCallersAsync, so walk
                     // every declaration body of the symbol (a partial method can have
-                    // several) and resolve each invocation / object creation through that
-                    // declaration's semantic model.
+                    // several) and resolve each invocation, object creation and
+                    // constructor initializer through that declaration's semantic model.
                     let callSitesByTarget =
                         System.Collections.Generic.Dictionary<ISymbol, ResizeArray<Ionide.LanguageServerProtocol.Types.Range>>(
                             SymbolEqualityComparer.Default
@@ -168,6 +168,7 @@ module CallHierarchy =
                                 let isCallNode (n: SyntaxNode) =
                                     n :? CSharp.Syntax.InvocationExpressionSyntax
                                     || n :? CSharp.Syntax.BaseObjectCreationExpressionSyntax
+                                    || n :? CSharp.Syntax.ConstructorInitializerSyntax
 
                                 for callNode in declNode.DescendantNodes() |> Seq.filter isCallNode do
                                     // Normalize to the original definition so constructed

--- a/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
+++ b/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
@@ -170,6 +170,22 @@ module CallHierarchy =
                                     || n :? CSharp.Syntax.BaseObjectCreationExpressionSyntax
                                     || n :? CSharp.Syntax.ConstructorInitializerSyntax
 
+                                // Anchor each call site at its callee name token, not at the
+                                // start of the whole expression: in a fluent chain every
+                                // link's invocation node begins at the chain head, so all
+                                // links would otherwise report the same position.
+                                let callAnchor (n: SyntaxNode) =
+                                    match n with
+                                    | :? CSharp.Syntax.InvocationExpressionSyntax as inv ->
+                                        match inv.Expression with
+                                        | :? CSharp.Syntax.MemberAccessExpressionSyntax as ma -> ma.Name.GetLocation()
+                                        | :? CSharp.Syntax.MemberBindingExpressionSyntax as mb -> mb.Name.GetLocation()
+                                        | expr -> expr.GetLocation()
+                                    | :? CSharp.Syntax.ObjectCreationExpressionSyntax as oc -> oc.Type.GetLocation()
+                                    | :? CSharp.Syntax.ConstructorInitializerSyntax as ci ->
+                                        ci.ThisOrBaseKeyword.GetLocation()
+                                    | _ -> n.GetLocation()
+
                                 for callNode in declNode.DescendantNodes() |> Seq.filter isCallNode do
                                     // Normalize to the original definition so constructed
                                     // generic instantiations (Echo<int>, Echo<string>)
@@ -182,7 +198,7 @@ module CallHierarchy =
                                     match target with
                                     | Some target when isCallableSymbol target ->
                                         let range =
-                                            callNode.GetLocation().GetLineSpan().Span |> Range.fromLinePositionSpan
+                                            (callAnchor callNode).GetLineSpan().Span |> Range.fromLinePositionSpan
 
                                         match callSitesByTarget.TryGetValue target with
                                         | true, ranges -> ranges.Add range

--- a/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
+++ b/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
@@ -170,7 +170,13 @@ module CallHierarchy =
                                     || n :? CSharp.Syntax.BaseObjectCreationExpressionSyntax
 
                                 for callNode in declNode.DescendantNodes() |> Seq.filter isCallNode do
-                                    let target = semanticModel.GetSymbolInfo(callNode, ct).Symbol |> Option.ofObj
+                                    // Normalize to the original definition so constructed
+                                    // generic instantiations (Echo<int>, Echo<string>)
+                                    // group as one target.
+                                    let target =
+                                        semanticModel.GetSymbolInfo(callNode, ct).Symbol
+                                        |> Option.ofObj
+                                        |> Option.map _.OriginalDefinition
 
                                     match target with
                                     | Some target when isCallableSymbol target ->

--- a/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
+++ b/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
@@ -151,7 +151,10 @@ module CallHierarchy =
                     // several) and resolve each invocation, object creation and
                     // constructor initializer through that declaration's semantic model.
                     let callSitesByTarget =
-                        System.Collections.Generic.Dictionary<ISymbol, ResizeArray<Ionide.LanguageServerProtocol.Types.Range>>(
+                        System.Collections.Generic.Dictionary<
+                            ISymbol,
+                            ResizeArray<Ionide.LanguageServerProtocol.Types.Range>
+                         >(
                             SymbolEqualityComparer.Default
                         )
 

--- a/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
+++ b/src/CSharpLanguageServer/Handlers/CallHierarchy.fs
@@ -132,11 +132,77 @@ module CallHierarchy =
         }
 
     let outgoingCalls
-        (_context: RequestContext)
-        (_: CallHierarchyOutgoingCallsParams)
+        (context: RequestContext)
+        (p: CallHierarchyOutgoingCallsParams)
         : Async<LspResult<CallHierarchyOutgoingCall[] option> * LspWorkspaceUpdate> =
         async {
-            // TODO: There is no memthod of SymbolFinder which can find all outgoing calls of a specific symbol.
-            // Then how can we implement it? Parsing AST manually?
-            return None |> LspResult.success, LspWorkspaceUpdate.Empty
+            let! ct = Async.CancellationToken
+
+            let! wf, solution = p.Item.Uri |> context.LoadWorkspaceFolder
+
+            match wf, solution with
+            | Some wf, Some solution ->
+                let! symInfo = workspaceFolderDocumentSymbol AnyDocument p.Item.Uri p.Item.Range.Start wf
+
+                match symInfo with
+                | Some(symbol, _, _) when isCallableSymbol symbol ->
+                    // SymbolFinder has no outgoing counterpart to FindCallersAsync, so walk
+                    // every declaration body of the symbol (a partial method can have
+                    // several) and resolve each invocation / object creation through that
+                    // declaration's semantic model.
+                    let callSitesByTarget =
+                        System.Collections.Generic.Dictionary<ISymbol, ResizeArray<Ionide.LanguageServerProtocol.Types.Range>>(
+                            SymbolEqualityComparer.Default
+                        )
+
+                    for syntaxRef in symbol.DeclaringSyntaxReferences do
+                        match solution.GetDocument(syntaxRef.SyntaxTree) |> Option.ofObj with
+                        | None -> ()
+                        | Some doc ->
+                            let! semanticModel = doc.GetSemanticModelAsync(ct) |> Async.AwaitTask
+                            let! declNode = syntaxRef.GetSyntaxAsync(ct) |> Async.AwaitTask
+
+                            match semanticModel |> Option.ofObj with
+                            | None -> ()
+                            | Some(semanticModel: SemanticModel) ->
+                                let isCallNode (n: SyntaxNode) =
+                                    n :? CSharp.Syntax.InvocationExpressionSyntax
+                                    || n :? CSharp.Syntax.BaseObjectCreationExpressionSyntax
+
+                                for callNode in declNode.DescendantNodes() |> Seq.filter isCallNode do
+                                    let target = semanticModel.GetSymbolInfo(callNode, ct).Symbol |> Option.ofObj
+
+                                    match target with
+                                    | Some target when isCallableSymbol target ->
+                                        let range =
+                                            callNode.GetLocation().GetLineSpan().Span |> Range.fromLinePositionSpan
+
+                                        match callSitesByTarget.TryGetValue target with
+                                        | true, ranges -> ranges.Add range
+                                        | false, _ -> callSitesByTarget[target] <- ResizeArray [ range ]
+                                    | _ -> ()
+
+                    let wfPathToUri path = workspaceFolderPathToUri path wf
+
+                    // Targets without a source location (e.g. BCL symbols) are dropped,
+                    // mirroring what incomingCalls does for callers.
+                    let toOutgoingCall (KeyValue(target: ISymbol, ranges)) =
+                        target.Locations
+                        |> Seq.choose (Location.fromRoslynLocation wfPathToUri)
+                        |> Seq.tryHead
+                        |> Option.map (fun loc ->
+                            { To = CallHierarchyItem.fromSymbolAndLocation target loc
+                              FromRanges = ranges |> Seq.toArray })
+
+                    return
+                        callSitesByTarget
+                        |> Seq.choose toOutgoingCall
+                        |> Seq.toArray
+                        |> Some
+                        |> LspResult.success,
+                        LspWorkspaceUpdate.Empty
+
+                | _ -> return None |> LspResult.success, LspWorkspaceUpdate.Empty
+
+            | _, _ -> return None |> LspResult.success, LspWorkspaceUpdate.Empty
         }

--- a/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
+++ b/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
@@ -157,8 +157,7 @@ let testCallHierarchyOutgoingCallsCoverComplexCallSites () =
         match outgoingCallsResult with
         | None -> ClassicAssert.Fail("outgoingCalls should return a result")
         | Some outgoingCalls ->
-            let byName =
-                outgoingCalls |> Array.map (fun c -> c.To.Name, c) |> Array.sortBy fst
+            let byName = outgoingCalls |> Array.map (fun c -> c.To.Name, c) |> Array.sortBy fst
 
             ClassicAssert.AreEqual(
                 [| "Helper(int)"; "LocalHelper()"; "Render()"; "Widget()" |],
@@ -209,8 +208,7 @@ let testCallHierarchyOutgoingCallsGroupConstructedGenericsAndFindExtensionMethod
         match outgoingCallsResult with
         | None -> ClassicAssert.Fail("outgoingCalls should return a result")
         | Some outgoingCalls ->
-            let byName =
-                outgoingCalls |> Array.map (fun c -> c.To.Name, c) |> Array.sortBy fst
+            let byName = outgoingCalls |> Array.map (fun c -> c.To.Name, c) |> Array.sortBy fst
 
             // Echo<int> and Echo<string> are the SAME method: constructed
             // generics must group to one target under the original definition.
@@ -306,8 +304,7 @@ let testCallHierarchyOutgoingCallsAnchorAtTheCalleeNameToken () =
         | Some outgoingCalls ->
             ClassicAssert.AreEqual(1, outgoingCalls.Length, "Both chain links call the same method")
 
-            let stepLines =
-                outgoingCalls[0].FromRanges |> Array.map _.Start.Line |> Array.sort
+            let stepLines = outgoingCalls[0].FromRanges |> Array.map _.Start.Line |> Array.sort
 
             ClassicAssert.AreEqual(
                 [| 72u; 73u |],

--- a/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
+++ b/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
@@ -52,6 +52,135 @@ let testCallHierarchyIncomingCallsWorks () =
             ClassicAssert.AreEqual(12u, incomingCall.FromRanges[0].Start.Line, "Call site should be on line 12")
 
 [<Test>]
+let testCallHierarchyOutgoingCallsWorks () =
+    use client = activateFixture "genericProject"
+    use classFile = client.Open "Project/Class.cs"
+
+    // Step 1: Prepare call hierarchy for MethodB (line 10, char 16 is where "MethodB" is)
+    let prepareParams: CallHierarchyPrepareParams =
+        { TextDocument = { Uri = classFile.Uri }
+          Position = { Line = 10u; Character = 16u }
+          WorkDoneToken = None }
+
+    let prepareResult: CallHierarchyItem[] option =
+        client.Request("textDocument/prepareCallHierarchy", prepareParams)
+
+    match prepareResult with
+    | None -> ClassicAssert.Fail("prepareCallHierarchy should return a result for MethodB")
+    | Some items ->
+        ClassicAssert.AreEqual(1, items.Length)
+
+        let methodBItem = items[0]
+        ClassicAssert.AreEqual("MethodB(string)", methodBItem.Name)
+
+        // Step 2: Get outgoing calls for MethodB - should find the call to MethodA
+        let outgoingCallsParams: CallHierarchyOutgoingCallsParams =
+            { Item = methodBItem
+              WorkDoneToken = None
+              PartialResultToken = None }
+
+        let outgoingCallsResult: CallHierarchyOutgoingCall[] option =
+            client.Request("callHierarchy/outgoingCalls", outgoingCallsParams)
+
+        match outgoingCallsResult with
+        | None -> ClassicAssert.Fail("outgoingCalls should return a result")
+        | Some outgoingCalls ->
+            ClassicAssert.AreEqual(1, outgoingCalls.Length)
+
+            let outgoingCall = outgoingCalls[0]
+            ClassicAssert.AreEqual("MethodA(string)", outgoingCall.To.Name)
+            ClassicAssert.AreEqual(SymbolKind.Method, outgoingCall.To.Kind)
+
+            // FromRanges should point to the call site of MethodA inside MethodB (line 12)
+            ClassicAssert.AreEqual(1, outgoingCall.FromRanges.Length, "Should have one call site")
+            ClassicAssert.AreEqual(12u, outgoingCall.FromRanges[0].Start.Line, "Call site should be on line 12")
+
+[<Test>]
+let testCallHierarchyOutgoingCallsReturnsEmptyNotNullWhenNoVisibleTargets () =
+    use client = activateFixture "genericProject"
+    use classFile = client.Open "Project/Class.cs"
+
+    // MethodA (line 4, char 16) only calls Console.WriteLine, which lives in
+    // metadata and has no source location, so the result should be an EMPTY
+    // array (an honest "nothing to show"), not null ("unsupported").
+    let prepareParams: CallHierarchyPrepareParams =
+        { TextDocument = { Uri = classFile.Uri }
+          Position = { Line = 4u; Character = 16u }
+          WorkDoneToken = None }
+
+    let prepareResult: CallHierarchyItem[] option =
+        client.Request("textDocument/prepareCallHierarchy", prepareParams)
+
+    match prepareResult with
+    | None -> ClassicAssert.Fail("prepareCallHierarchy should return a result for MethodA")
+    | Some items ->
+        let outgoingCallsParams: CallHierarchyOutgoingCallsParams =
+            { Item = items[0]
+              WorkDoneToken = None
+              PartialResultToken = None }
+
+        let outgoingCallsResult: CallHierarchyOutgoingCall[] option =
+            client.Request("callHierarchy/outgoingCalls", outgoingCallsParams)
+
+        match outgoingCallsResult with
+        | None -> ClassicAssert.Fail("outgoingCalls should return [] for a callable symbol, not null")
+        | Some outgoingCalls -> ClassicAssert.AreEqual(0, outgoingCalls.Length)
+
+[<Test>]
+let testCallHierarchyOutgoingCallsCoverComplexCallSites () =
+    use client = activateFixture "genericProject"
+    use testFile = client.Open "Project/OutgoingCallsTest.cs"
+
+    // Prepare on Orchestrator (line 4, char 16), whose body mixes call shapes:
+    // a constructor call, a call inside a lambda, a local function invocation,
+    // a call inside the local function's body, a delegate Invoke (metadata,
+    // dropped) and a plain instance call.
+    let prepareParams: CallHierarchyPrepareParams =
+        { TextDocument = { Uri = testFile.Uri }
+          Position = { Line = 4u; Character = 16u }
+          WorkDoneToken = None }
+
+    let prepareResult: CallHierarchyItem[] option =
+        client.Request("textDocument/prepareCallHierarchy", prepareParams)
+
+    match prepareResult with
+    | None -> ClassicAssert.Fail("prepareCallHierarchy should return a result for Orchestrator")
+    | Some items ->
+        let outgoingCallsParams: CallHierarchyOutgoingCallsParams =
+            { Item = items[0]
+              WorkDoneToken = None
+              PartialResultToken = None }
+
+        let outgoingCallsResult: CallHierarchyOutgoingCall[] option =
+            client.Request("callHierarchy/outgoingCalls", outgoingCallsParams)
+
+        match outgoingCallsResult with
+        | None -> ClassicAssert.Fail("outgoingCalls should return a result")
+        | Some outgoingCalls ->
+            let byName =
+                outgoingCalls |> Array.map (fun c -> c.To.Name, c) |> Array.sortBy fst
+
+            ClassicAssert.AreEqual(
+                [| "Helper(int)"; "LocalHelper()"; "Render()"; "Widget()" |],
+                byName |> Array.map fst,
+                "Expected the ctor, the lambda/local-function targets and the instance call; delegate Invoke has no source and is dropped"
+            )
+
+            let call name =
+                byName |> Array.find (fun (n, _) -> n = name) |> snd
+
+            // Helper is called twice: from the lambda (line 7) and from inside
+            // the local function's body (line 14) - both attribute to Orchestrator.
+            let helperLines =
+                (call "Helper(int)").FromRanges |> Array.map _.Start.Line |> Array.sort
+
+            ClassicAssert.AreEqual([| 7u; 14u |], helperLines)
+
+            ClassicAssert.AreEqual(6u, (call "Widget()").FromRanges[0].Start.Line, "ctor call site")
+            ClassicAssert.AreEqual(8u, (call "LocalHelper()").FromRanges[0].Start.Line, "local function call site")
+            ClassicAssert.AreEqual(10u, (call "Render()").FromRanges[0].Start.Line, "instance call site")
+
+[<Test>]
 let testCallHierarchyPrepareReturnsNoneForNonCallableSymbol () =
     use client = activateFixture "genericProject"
     use classFile = client.Open "Project/Class.cs"

--- a/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
+++ b/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
@@ -181,6 +181,55 @@ let testCallHierarchyOutgoingCallsCoverComplexCallSites () =
             ClassicAssert.AreEqual(10u, (call "Render()").FromRanges[0].Start.Line, "instance call site")
 
 [<Test>]
+let testCallHierarchyOutgoingCallsGroupConstructedGenericsAndFindExtensionMethods () =
+    use client = activateFixture "genericProject"
+    use testFile = client.Open "Project/OutgoingCallsTest.cs"
+
+    // CallsBoth (line 34, char 16) invokes Echo<T> twice with different type
+    // arguments plus a user-defined extension method in instance form.
+    let prepareParams: CallHierarchyPrepareParams =
+        { TextDocument = { Uri = testFile.Uri }
+          Position = { Line = 34u; Character = 16u }
+          WorkDoneToken = None }
+
+    let prepareResult: CallHierarchyItem[] option =
+        client.Request("textDocument/prepareCallHierarchy", prepareParams)
+
+    match prepareResult with
+    | None -> ClassicAssert.Fail("prepareCallHierarchy should return a result for CallsBoth")
+    | Some items ->
+        let outgoingCallsParams: CallHierarchyOutgoingCallsParams =
+            { Item = items[0]
+              WorkDoneToken = None
+              PartialResultToken = None }
+
+        let outgoingCallsResult: CallHierarchyOutgoingCall[] option =
+            client.Request("callHierarchy/outgoingCalls", outgoingCallsParams)
+
+        match outgoingCallsResult with
+        | None -> ClassicAssert.Fail("outgoingCalls should return a result")
+        | Some outgoingCalls ->
+            let byName =
+                outgoingCalls |> Array.map (fun c -> c.To.Name, c) |> Array.sortBy fst
+
+            // Echo<int> and Echo<string> are the SAME method: constructed
+            // generics must group to one target under the original definition.
+            ClassicAssert.AreEqual(
+                [| "Echo<T>(T)"; "Shout()" |],
+                byName |> Array.map fst,
+                "Constructed generic instantiations should group to one target; the extension method should be found"
+            )
+
+            let call name =
+                byName |> Array.find (fun (n, _) -> n = name) |> snd
+
+            let echoLines =
+                (call "Echo<T>(T)").FromRanges |> Array.map _.Start.Line |> Array.sort
+
+            ClassicAssert.AreEqual([| 36u; 37u |], echoLines, "Both instantiations' call sites should be present")
+            ClassicAssert.AreEqual(38u, (call "Shout()").FromRanges[0].Start.Line, "extension method call site")
+
+[<Test>]
 let testCallHierarchyPrepareReturnsNoneForNonCallableSymbol () =
     use client = activateFixture "genericProject"
     use classFile = client.Open "Project/Class.cs"

--- a/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
+++ b/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
@@ -271,6 +271,51 @@ let testCallHierarchyOutgoingCallsIncludeConstructorInitializers () =
     ClassicAssert.AreEqual(62u, fromSized[0].FromRanges[0].Start.Line, "base(size) call site")
 
 [<Test>]
+let testCallHierarchyOutgoingCallsAnchorAtTheCalleeNameToken () =
+    use client = activateFixture "genericProject"
+    use testFile = client.Open "Project/OutgoingCallsTest.cs"
+
+    // Start (line 69, char 23) is a multi-line fluent chain:
+    //     return this
+    //         .Step()      <- line 72
+    //         .Step();     <- line 73
+    // Each call site must anchor at ITS callee name token, not at the start
+    // of the invocation expression (which is the chain head on line 71 for
+    // both).
+    let prepareParams: CallHierarchyPrepareParams =
+        { TextDocument = { Uri = testFile.Uri }
+          Position = { Line = 69u; Character = 23u }
+          WorkDoneToken = None }
+
+    let prepareResult: CallHierarchyItem[] option =
+        client.Request("textDocument/prepareCallHierarchy", prepareParams)
+
+    match prepareResult with
+    | None -> ClassicAssert.Fail("prepareCallHierarchy should return a result for Start")
+    | Some items ->
+        let outgoingCallsParams: CallHierarchyOutgoingCallsParams =
+            { Item = items[0]
+              WorkDoneToken = None
+              PartialResultToken = None }
+
+        let outgoingCallsResult: CallHierarchyOutgoingCall[] option =
+            client.Request("callHierarchy/outgoingCalls", outgoingCallsParams)
+
+        match outgoingCallsResult with
+        | None -> ClassicAssert.Fail("outgoingCalls should return a result")
+        | Some outgoingCalls ->
+            ClassicAssert.AreEqual(1, outgoingCalls.Length, "Both chain links call the same method")
+
+            let stepLines =
+                outgoingCalls[0].FromRanges |> Array.map _.Start.Line |> Array.sort
+
+            ClassicAssert.AreEqual(
+                [| 72u; 73u |],
+                stepLines,
+                "Each chained call should anchor on its own callee name line"
+            )
+
+[<Test>]
 let testCallHierarchyPrepareReturnsNoneForNonCallableSymbol () =
     use client = activateFixture "genericProject"
     use classFile = client.Open "Project/Class.cs"

--- a/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
+++ b/tests/CSharpLanguageServer.Tests/CallHierarchyTests.fs
@@ -230,6 +230,47 @@ let testCallHierarchyOutgoingCallsGroupConstructedGenericsAndFindExtensionMethod
             ClassicAssert.AreEqual(38u, (call "Shout()").FromRanges[0].Start.Line, "extension method call site")
 
 [<Test>]
+let testCallHierarchyOutgoingCallsIncludeConstructorInitializers () =
+    use client = activateFixture "genericProject"
+    use testFile = client.Open "Project/OutgoingCallsTest.cs"
+
+    let outgoingFor (line: uint32) (character: uint32) =
+        let prepareParams: CallHierarchyPrepareParams =
+            { TextDocument = { Uri = testFile.Uri }
+              Position = { Line = line; Character = character }
+              WorkDoneToken = None }
+
+        let prepareResult: CallHierarchyItem[] option =
+            client.Request("textDocument/prepareCallHierarchy", prepareParams)
+
+        match prepareResult with
+        | None -> failwithf "prepareCallHierarchy should return a result at %d:%d" line character
+        | Some items ->
+            let outgoingCallsParams: CallHierarchyOutgoingCallsParams =
+                { Item = items[0]
+                  WorkDoneToken = None
+                  PartialResultToken = None }
+
+            let result: CallHierarchyOutgoingCall[] option =
+                client.Request("callHierarchy/outgoingCalls", outgoingCallsParams)
+
+            match result with
+            | None -> failwithf "outgoingCalls should return a result at %d:%d" line character
+            | Some calls -> calls
+
+    // ChainDerived() : this(5) - the chained ctor is an outgoing call (line 58)
+    let fromParameterless = outgoingFor 58u 11u
+    ClassicAssert.AreEqual(1, fromParameterless.Length)
+    ClassicAssert.AreEqual("ChainDerived(int)", fromParameterless[0].To.Name)
+    ClassicAssert.AreEqual(58u, fromParameterless[0].FromRanges[0].Start.Line, "this(5) call site")
+
+    // ChainDerived(int) : base(size) - the base ctor is an outgoing call (line 62)
+    let fromSized = outgoingFor 62u 11u
+    ClassicAssert.AreEqual(1, fromSized.Length)
+    ClassicAssert.AreEqual("ChainBase(int)", fromSized[0].To.Name)
+    ClassicAssert.AreEqual(62u, fromSized[0].FromRanges[0].Start.Line, "base(size) call site")
+
+[<Test>]
 let testCallHierarchyPrepareReturnsNoneForNonCallableSymbol () =
     use client = activateFixture "genericProject"
     use classFile = client.Open "Project/Class.cs"

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
@@ -1,0 +1,31 @@
+using System;
+
+class OutgoingComplex
+{
+    public void Orchestrator()
+    {
+        var w = new Widget();
+        Func<int, int> f = x => Helper(x);
+        LocalHelper();
+        f(2);
+        w.Render();
+
+        void LocalHelper()
+        {
+            Helper(7);
+        }
+    }
+
+    public int Helper(int x) => x;
+}
+
+class Widget
+{
+    public Widget()
+    {
+    }
+
+    public void Render()
+    {
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
@@ -64,3 +64,15 @@ class ChainDerived : ChainBase
     {
     }
 }
+
+class FluentChain
+{
+    public FluentChain Start()
+    {
+        return this
+            .Step()
+            .Step();
+    }
+
+    public FluentChain Step() => this;
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
@@ -46,3 +46,21 @@ static class StringExtensions
 {
     public static string Shout(this string s) => s.ToUpperInvariant();
 }
+
+class ChainBase
+{
+    public ChainBase(int size)
+    {
+    }
+}
+
+class ChainDerived : ChainBase
+{
+    public ChainDerived() : this(5)
+    {
+    }
+
+    public ChainDerived(int size) : base(size)
+    {
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/genericProject/Project/OutgoingCallsTest.cs
@@ -29,3 +29,20 @@ class Widget
     {
     }
 }
+
+class GenericCalls
+{
+    public void CallsBoth()
+    {
+        Echo(1);
+        Echo("s");
+        "x".Shout();
+    }
+
+    public T Echo<T>(T value) => value;
+}
+
+static class StringExtensions
+{
+    public static string Shout(this string s) => s.ToUpperInvariant();
+}


### PR DESCRIPTION
Closes #407.

csharp-ls advertises `callHierarchyProvider` but `callHierarchy/outgoingCalls`
has been a stub returning `null`. I consume the call hierarchy in both
directions from a code intelligence tool running over my production C#
monorepo: incoming works, outgoing silently returns nothing, and a client
cannot tell "unsupported" from "this method calls nothing".

The TODO in the handler asks whether this needs manual AST parsing, since
`SymbolFinder` has no outgoing counterpart to `FindCallersAsync`. It does not
need a hand rolled walk: the declaration's semantic model already answers it.
The handler now

- resolves the prepared item back to its symbol (the same path `incomingCalls` uses),
- walks every `DeclaringSyntaxReferences` body (a partial method has several),
- collects invocations and object creations (including target-typed `new`)
  and resolves each through that declaration's semantic model,
- groups call sites per target symbol and emits one `CallHierarchyOutgoingCall`
  per target with the call sites as `fromRanges`.

Behavior, pinned by tests:

- calls inside lambdas and local functions attribute to the containing
  member, and a local function invocation is itself a target
- constructor calls resolve to the constructor
- constructed generic instantiations (Echo<int>, Echo<string>) group to one
  target under the original definition, and user-defined extension methods
  called in instance form are found
- constructor initializers (`: base(...)` and `: this(...)`) count as
  outgoing calls
- `fromRanges` anchor at the callee name token, so every link of a
  (multi-line) fluent chain reports its own position instead of the chain
  head
- targets without a source location (BCL symbols, delegate `Invoke`) are
  dropped, mirroring what `incomingCalls` does with callers
- a callable symbol with no visible targets returns `[]` instead of `null`,
  so "calls nothing" is distinguishable from "unsupported"

Out of scope for now: surfacing metadata targets when `useMetadataUris` is
enabled (that would reuse the `workspaceFolderSymbolLocations` path `prepare`
uses), and counting property/field accessor use (getter/setter calls,
object-initializer assignments) as calls. Also note that top-level-statement
bodies are unreachable for the whole call-hierarchy feature because
`prepareCallHierarchy` returns no item inside the implicit `Main`; that
predates this change.

Six new tests in `CallHierarchyTests.fs`, including a fixture that mixes a
ctor call, a call inside a lambda, a local function, a delegate invoke, a
plain instance call, generic instantiations, an extension method, a ctor
chain and a multi-line fluent chain.

Beyond the unit tests I validated the implementation against a fixture
repository where I hand-counted every in-solution invocation and object
creation: 97/97 call sites matched exactly, zero misses and zero phantom
edges, with overload families (arity, named args, params, out-var, generics),
decoy symbols, facade indirections, partials split across files and
deliberately unresolvable calls all landing on the compiler-correct target. Full suite passes locally, apart from a few
timing-sensitive JsonRpc timeout tests that flake under parallel load
independent of this change (they pass in isolation).
