### PR TITLE
Fix test-suite hang: kill a timed-out fixture build before reading its output

### DIFF
--- a/tests/CSharpLanguageServer.Tests/Tooling.fs
+++ b/tests/CSharpLanguageServer.Tests/Tooling.fs
@@ -1011,7 +1011,14 @@ let runDotnetBuild (dir: string) =
     dotnetBuildSemaphore.Wait()
 
     try
-        let psi = ProcessStartInfo("dotnet", "build")
+        // -nodeReuse:false / UseSharedCompilation=false: MSBuild worker nodes and
+        // the shared compiler server outlive the build and inherit the redirected
+        // stdout/stderr descriptors, so ReadToEndAsync never sees EOF even after
+        // `dotnet build` itself has exited (observed in CI hang dumps as a thread
+        // parked forever in Task.GetResultCore inside this function).
+        let psi =
+            ProcessStartInfo("dotnet", "build -nodeReuse:false -p:UseSharedCompilation=false")
+
         psi.WorkingDirectory <- dir
         psi.RedirectStandardOutput <- true
         psi.RedirectStandardError <- true
@@ -1030,15 +1037,22 @@ let runDotnetBuild (dir: string) =
         let exited = proc.WaitForExit(120_000)
 
         if not exited then
-            // Kill BEFORE reading the output tasks: ReadToEndAsync only
-            // completes once the child closes its pipes, so reading first
-            // would block forever on a hung build, the kill would never run
-            // and dotnetBuildSemaphore would be held for the rest of the run.
+            // Kill BEFORE reading the output tasks: reading first would block on
+            // a hung build, the kill would never run and dotnetBuildSemaphore
+            // would be held for the rest of the run.
             proc.Kill(entireProcessTree = true)
             proc.WaitForExit()
 
-        let stdout = stdoutTask.Result
-        let stderr = stderrTask.Result
+        // Belt and braces: even with the flags above, never block forever on a
+        // pipe some straggler child may still hold open.
+        let readOrGiveUp (t: Task<string>) =
+            if t.Wait(30_000) then
+                t.Result
+            else
+                "(build output unavailable: the pipe is still held open by a child process)"
+
+        let stdout = readOrGiveUp stdoutTask
+        let stderr = readOrGiveUp stderrTask
 
         if not exited then
             failwithf "dotnet build timed out after 120 seconds\nstdout:\n%s\nstderr:\n%s" stdout stderr

--- a/tests/CSharpLanguageServer.Tests/Tooling.fs
+++ b/tests/CSharpLanguageServer.Tests/Tooling.fs
@@ -1028,11 +1028,19 @@ let runDotnetBuild (dir: string) =
         let stderrTask = proc.StandardError.ReadToEndAsync()
 
         let exited = proc.WaitForExit(120_000)
+
+        if not exited then
+            // Kill BEFORE reading the output tasks: ReadToEndAsync only
+            // completes once the child closes its pipes, so reading first
+            // would block forever on a hung build, the kill would never run
+            // and dotnetBuildSemaphore would be held for the rest of the run.
+            proc.Kill(entireProcessTree = true)
+            proc.WaitForExit()
+
         let stdout = stdoutTask.Result
         let stderr = stderrTask.Result
 
         if not exited then
-            proc.Kill(entireProcessTree = true)
             failwithf "dotnet build timed out after 120 seconds\nstdout:\n%s\nstderr:\n%s" stdout stderr
 
         proc.ExitCode, stdout, stderr


### PR DESCRIPTION
The CI test runs currently hang and get aborted by the blame-hang timeout
(main's own run for 95f313e fails this way, as does the run on #412). I pulled
the hang dump the ubuntu job uploaded (`dotnet_7534_20260820T073825_hangdump.dmp`
from run 32343896118) and analyzed it with dotnet-dump. All 286 tests that
executed had passed; the two threads still running were both inside
`Tooling.runDotnetBuild`:

- the `testPlatformSpecificTfmDoesNotBreakSiblingProjects` prebuild, blocked
  in `Task.GetResultCore` on `stdoutTask.Result`,
- the `SourceGeneratorTests` prebuild, queued behind it on
  `dotnetBuildSemaphore`.

`ProxyGenerator` / Castle frames appear in none of the stacks, so the lock
added in 95f313e was likely chasing this same hang: an ordering bug in
`runDotnetBuild`'s timeout path.

```fsharp
let exited = proc.WaitForExit(120_000)
let stdout = stdoutTask.Result   // ReadToEndAsync only completes when the
let stderr = stderrTask.Result   // child closes its pipes...
if not exited then
    proc.Kill(entireProcessTree = true)   // ...so this is unreachable
```

When a fixture build exceeds 120 seconds (cold CI NuGet cache; the
net10.0-windows TFM fixture is a likely candidate), the read blocks forever,
the kill never runs, the semaphore is never released, and every later fixture
build queues behind it until the blame-hang timeout aborts the host. Locally
this never reproduces because warm caches keep fixture builds in seconds.

The fix kills the timed-out process (and waits for it to exit, which closes
the pipes) before reading the output tasks, so the timeout branch actually
fires and still reports the captured build output.

No new test: exercising the timeout path would require a fixture whose build
blocks for over two minutes. Verified against the hang dump above and by
running the affected test classes (InitializationTests, SourceGeneratorTests)
locally.
