### PR TITLE
perf: resolve documents via GetDocumentIdsWithFilePath instead of scanning all documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Speed up the per-request document lookup: resolve the request uri through Roslyn's indexed `Solution.GetDocumentIdsWithFilePath` instead of scanning every document of every project (~6x faster `textDocument/definition` on a large solution)
+  - By @pbednarcik in https://github.com/razzmatazz/csharp-language-server/pull/414
 * Implement `callHierarchy/outgoingCalls`, previously a stub returning `null`; the handler resolves the prepared item back to its symbol, walks its declaration bodies for invocations and object creations, and resolves each through the semantic model
   - By @pbednarcik in https://github.com/razzmatazz/csharp-language-server/pull/412
 * Fix `textDocument/references` and `callHierarchy/incomingCalls` leaking a dynamic assembly (and associated loader handles) on every request; `WorkspaceServicesInterceptor`'s `ProxyGenerator` is now created once (`static let`) instead of per-call

--- a/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
+++ b/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
@@ -424,8 +424,17 @@ let workspaceFolderDocumentDetails docType (u: string) (wf: LspWorkspaceFolder) 
         let matchingUserDocumentMaybe =
             workspaceFolderUriToPath u wf
             |> Option.bind (fun path ->
-                match solution.GetDocumentIdsWithFilePath path |> List.ofSeq with
-                | [ docId ] -> solution.GetDocument docId |> Option.ofObj
+                // The ids can include non-source documents (additional /
+                // analyzer-config files, depending on the Roslyn version), so
+                // resolve through GetDocument first and require exactly one
+                // SOURCE document, matching the previous scan over
+                // project.Documents only.
+                match
+                    solution.GetDocumentIdsWithFilePath path
+                    |> Seq.choose (fun docId -> solution.GetDocument docId |> Option.ofObj)
+                    |> List.ofSeq
+                with
+                | [ doc ] -> Some doc
                 | _ -> None)
             |> Option.map (fun d -> d, UserDocument)
 

--- a/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
+++ b/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
@@ -410,23 +410,24 @@ let workspaceFolderSymbolsLocations
     }
 
 let workspaceFolderDocumentDetails docType (u: string) (wf: LspWorkspaceFolder) =
-    let uri = Uri(u.Replace("%3A", ":", true, null))
-
     match wf.Solution with
     | Uninitialized -> None
     | Loading -> None
     | Defunct _ -> None
     | Loaded(_, solution) ->
-        let matchingUserDocuments =
-            solution.Projects
-            |> Seq.collect _.Documents
-            |> Seq.filter (fun d -> Uri(d.FilePath, UriKind.Absolute) = uri)
-            |> List.ofSeq
-
+        // Indexed lookup instead of scanning every document of every project:
+        // this runs on every position-based request, so on a large solution
+        // the scan (which also allocated a Uri per document for the
+        // comparison) dominates the per-request cost. Multiple ids for one
+        // path (e.g. a multi-targeted or linked file) keep resolving to None,
+        // matching the previous exactly-one-match behavior.
         let matchingUserDocumentMaybe =
-            match matchingUserDocuments with
-            | [ d ] -> Some(d, UserDocument)
-            | _ -> None
+            workspaceFolderUriToPath u wf
+            |> Option.bind (fun path ->
+                match solution.GetDocumentIdsWithFilePath path |> List.ofSeq with
+                | [ docId ] -> solution.GetDocument docId |> Option.ofObj
+                | _ -> None)
+            |> Option.map (fun d -> d, UserDocument)
 
         let matchingDecompiledDocumentMaybe =
             match workspaceFolderParseCSharpDocumentUri u wf with

--- a/tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
+++ b/tests/CSharpLanguageServer.Tests/CSharpLanguageServer.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="RequestSchedulingTests.fs" />
     <Compile Include="DocumentSyncTests.fs" />
     <Compile Include="WorkspaceTests.fs" />
+    <Compile Include="WorkspaceFolderTests.fs" />
     <Compile Include="WorkspaceFolderRegressionTests.fs" />
     <Compile Include="CallHierarchyTests.fs" />
     <Compile Include="FoldingRangeTests.fs" />

--- a/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
@@ -1,0 +1,141 @@
+module CSharpLanguageServer.Tests.WorkspaceFolderTests
+
+open System
+open System.IO
+open System.Text.RegularExpressions
+
+open Microsoft.CodeAnalysis
+open Microsoft.CodeAnalysis.Text
+open NUnit.Framework
+open NUnit.Framework.Legacy
+
+open CSharpLanguageServer.Lsp.WorkspaceFolder
+
+let private testFilePath name =
+    Path.Combine(Path.GetTempPath(), "CsLsWorkspaceFolderTests", name)
+
+let private fileUri (path: string) = Uri(path).AbsoluteUri
+
+/// Encode the drive colon the way VS Code does (file:///c%3A/...). On
+/// non-Windows paths (no drive letter) this is a no-op.
+let private vsCodeStyleUri (path: string) =
+    Regex.Replace(fileUri path, "^file:///([A-Za-z]):", "file:///$1%3A")
+
+let private addSourceDocument (solution: Solution) (projectId: ProjectId) name filePath =
+    let docInfo =
+        DocumentInfo.Create(
+            DocumentId.CreateNewId(projectId),
+            name,
+            filePath = filePath,
+            loader =
+                TextLoader.From(TextAndVersion.Create(SourceText.From("class Something {}"), VersionStamp.Create()))
+        )
+
+    solution.AddDocument(docInfo)
+
+let private makeWorkspaceFolder (solution: Solution) =
+    { LspWorkspaceFolder.Empty with
+        Solution = Loaded(solution.Workspace, solution) }
+
+let private makeSolutionWithProject () =
+    let ws = new AdhocWorkspace()
+    let project = ws.AddProject("Project", LanguageNames.CSharp)
+    ws.CurrentSolution, project.Id
+
+[<Test>]
+let ``document resolves by its file uri`` () =
+    let solution, projectId = makeSolutionWithProject ()
+    let path = testFilePath "Plain.cs"
+    let solution = addSourceDocument solution projectId "Plain.cs" path
+    let wf = makeWorkspaceFolder solution
+
+    match workspaceFolderDocument AnyDocument (fileUri path) wf with
+    | Some doc -> ClassicAssert.AreEqual(path, doc.FilePath)
+    | None -> ClassicAssert.Fail("document should resolve by its own uri")
+
+[<Test>]
+let ``document resolves by a vscode style uri with an encoded drive colon`` () =
+    let solution, projectId = makeSolutionWithProject ()
+    let path = testFilePath "Encoded.cs"
+    let solution = addSourceDocument solution projectId "Encoded.cs" path
+    let wf = makeWorkspaceFolder solution
+
+    match workspaceFolderDocument AnyDocument (vsCodeStyleUri path) wf with
+    | Some doc -> ClassicAssert.AreEqual(path, doc.FilePath)
+    | None -> ClassicAssert.Fail("document should resolve from a %3A-encoded uri")
+
+[<Test>]
+let ``document resolves from a differently cased uri`` () =
+    // Roslyn's file-path index compares with StringComparer.OrdinalIgnoreCase
+    // on every platform, so a client that cases the path differently still
+    // resolves. (System.Uri equality is also case-insensitive, so this
+    // matches the previous scan.)
+    let solution, projectId = makeSolutionWithProject ()
+    let path = testFilePath "Cased.cs"
+    let solution = addSourceDocument solution projectId "Cased.cs" path
+    let wf = makeWorkspaceFolder solution
+
+    match workspaceFolderDocument AnyDocument (fileUri (path.ToUpperInvariant())) wf with
+    | Some doc -> ClassicAssert.AreEqual(path, doc.FilePath)
+    | None -> ClassicAssert.Fail("document should resolve regardless of path casing")
+
+[<Test>]
+let ``a path shared by two projects resolves to none`` () =
+    let solution, projectId = makeSolutionWithProject ()
+    let path = testFilePath "Linked.cs"
+    let solution = addSourceDocument solution projectId "Linked.cs" path
+
+    let otherProject =
+        ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(), "Other", "Other", LanguageNames.CSharp)
+
+    let solution = solution.AddProject(otherProject)
+    let solution = addSourceDocument solution otherProject.Id "Linked.cs" path
+    let wf = makeWorkspaceFolder solution
+
+    ClassicAssert.IsTrue(
+        (workspaceFolderDocument AnyDocument (fileUri path) wf).IsNone,
+        "an ambiguous path (linked into two projects) should resolve to None"
+    )
+
+[<Test>]
+let ``a path that is also an additional document still resolves to the source document`` () =
+    // GetDocumentIdsWithFilePath returns ids for ALL document kinds, so the
+    // lookup must not treat a source document + additional document pair as
+    // ambiguous: only regular source documents count.
+    let solution, projectId = makeSolutionWithProject ()
+    let path = testFilePath "Dual.cs"
+    let solution = addSourceDocument solution projectId "Dual.cs" path
+
+    let solution =
+        solution.AddAdditionalDocument(
+            DocumentId.CreateNewId(projectId),
+            "Dual.cs",
+            SourceText.From("not source"),
+            filePath = path
+        )
+
+    let wf = makeWorkspaceFolder solution
+
+    match workspaceFolderDocument AnyDocument (fileUri path) wf with
+    | Some doc -> ClassicAssert.AreEqual(path, doc.FilePath)
+    | None -> ClassicAssert.Fail("the source document should win over a same-path additional document")
+
+[<Test>]
+let ``an additional-document-only path resolves to none`` () =
+    let solution, projectId = makeSolutionWithProject ()
+    let path = testFilePath "OnlyAdditional.txt"
+
+    let solution =
+        solution.AddAdditionalDocument(
+            DocumentId.CreateNewId(projectId),
+            "OnlyAdditional.txt",
+            SourceText.From("data"),
+            filePath = path
+        )
+
+    let wf = makeWorkspaceFolder solution
+
+    ClassicAssert.IsTrue(
+        (workspaceFolderDocument AnyDocument (fileUri path) wf).IsNone,
+        "a path known only as an additional document is not a source document"
+    )


### PR DESCRIPTION
Every position-based request (hover, definition, references,
prepareCallHierarchy, ...) resolves its URI to a document through
`workspaceFolderDocumentDetails`, which scans every document of every project
in the solution and allocates a `Uri` per document for the equality check. On
a large solution that scan dominates the whole request.

This PR switches the lookup to Roslyn's indexed
`Solution.GetDocumentIdsWithFilePath` (via the existing
`workspaceFolderUriToPath` helper). Multiple ids for one path (a
multi-targeted or linked file) keep resolving to None, matching the previous
exactly-one-match behavior.

Measured on my production C# monorepo (~120 projects), textDocument/definition
only, 12 concurrent requests, same machine, 3 minutes each, only this change
different:

| | scan (current) | indexed lookup |
|---|---|---|
| throughput | 1,846 req/s | **19,289 req/s (10.4x)** |
| CPU per request | ~4.6 ms | ~0.23 ms |
| server cores busy | 8.5 (saturated) | 4.4 (no longer the bottleneck) |

Memory per request is unchanged (~1.3 KB in both runs).

An end to end run of the indexing tool that drives these requests confirms
the numbers at scale: 176,748 definition requests over the same codebase
finish in 28.8s instead of 174.2s (6x), with identical request counts and
identical results on both builds, and the warm single-request path drops to
about 0.25 ms.

The lookup semantics are pinned by six new direct unit tests over an
AdhocWorkspace (WorkspaceFolderTests.fs): plain and %3A-encoded (VS Code
style) uris resolve, differently-cased paths resolve (both the old `Uri`
comparison and Roslyn's file-path index are case-insensitive, so this is
unchanged), an ambiguous path linked into two projects keeps resolving to
None, and a same-path additional document neither wins nor makes the source
document ambiguous (the ids from `GetDocumentIdsWithFilePath` are filtered
through `GetDocument` so only source documents participate, matching the
previous scan over `project.Documents`). The same six tests pass against the
pre-index scan, so the change is behavior-preserving, and the full suite
passes (every handler goes through this lookup).
