### PR TITLE
feat: report per-project progress while loading a solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Report per-project progress while loading a solution: `$/progress` reports now carry a message like `Project (34/88)` and a monotonically increasing percentage, so clients can display load progress and estimate readiness
+  - By @pbednarcik
 * Match request uris to workspace folders case-insensitively on Windows: Windows paths are case-insensitive, and a client may send a differently cased uri (for example a lowercase drive letter) than the announced workspace root, which previously made requests silently miss the workspace and answer null
   - By @pbednarcik
 * Fix `textDocument/references` with `includeDeclaration` crashing (`-32603 Internal error`) on a symbol from an assembly not referenced by an arbitrary "first" project in the solution; metadata locations are now resolved against the project that owns the requesting document instead

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -221,6 +221,44 @@ let resolveDefaultWorkspaceProps (targetFramework: string option) : Map<string, 
 
     Map.empty |> applyTargetFrameworkProp
 
+/// Turns MSBuildWorkspace's per-operation load progress into one progress
+/// report per project. A project goes through its Evaluate/Build/Resolve
+/// operations once per target framework, so completion is counted on the
+/// first Resolve seen for each project file.
+type private SolutionLoadProgressObserver(totalProjectCount: int, progressReport: string * uint -> Async<unit>) =
+    let completedProjects = HashSet<string>()
+    let syncRoot = obj ()
+
+    // Reports are forwarded through a mailbox so they reach the client in
+    // the order they were produced without blocking the loader's callback.
+    let reportQueue =
+        MailboxProcessor<string * uint>.Start(fun inbox -> async {
+            while true do
+                let! report = inbox.Receive()
+                do! progressReport report
+        })
+
+    interface IProgress<ProjectLoadProgress> with
+        member _.Report(loadProgress: ProjectLoadProgress) =
+            if loadProgress.Operation = ProjectLoadOperation.Resolve then
+                let reportMaybe =
+                    lock syncRoot (fun () ->
+                        match completedProjects.Add loadProgress.FilePath with
+                        | false -> None
+                        | true ->
+                            // The workspace may load more projects than the
+                            // solution file declares — LoadMetadataForReferencedProjects
+                            // follows references to non-member projects — so the
+                            // denominator widens as extras appear, keeping the
+                            // percentage monotonic and at most 100.
+                            let total = max totalProjectCount completedProjects.Count
+                            let percent = uint (100 * completedProjects.Count / max 1 total)
+                            let projectName = Path.GetFileNameWithoutExtension loadProgress.FilePath
+
+                            Some(sprintf "%s (%d/%d)" projectName completedProjects.Count total, percent))
+
+                reportMaybe |> Option.iter reportQueue.Post
+
 let selectPreferredSolution (slnFiles: string list) : option<string> =
     let getProjectCount (slnPath: string) =
         try
@@ -238,7 +276,11 @@ let selectPreferredSolution (slnFiles: string list) : option<string> =
         |> Seq.map snd
         |> Seq.tryHead
 
-let solutionTryLoadOnPath (lspClient: ILspClient) (solutionPath: string) : Async<option<Workspace * Solution>> =
+let solutionTryLoadOnPath
+    (lspClient: ILspClient)
+    (progressReport: string * uint -> Async<unit>)
+    (solutionPath: string)
+    : Async<option<Workspace * Solution>> =
     assert Path.IsPathRooted solutionPath
 
     let logMessage m =
@@ -267,7 +309,12 @@ let solutionTryLoadOnPath (lspClient: ILspClient) (solutionPath: string) : Async
 
             msbuildWorkspace.LoadMetadataForReferencedProjects <- true
 
-            let! solution = msbuildWorkspace.OpenSolutionAsync solutionPath |> Async.AwaitTask
+            let loadProgressObserver =
+                SolutionLoadProgressObserver(Set.count projs, progressReport)
+
+            let! solution =
+                msbuildWorkspace.OpenSolutionAsync(solutionPath, progress = loadProgressObserver)
+                |> Async.AwaitTask
 
             for diag in msbuildWorkspace.Diagnostics do
                 logger.LogInformation("msbuildWorkspace.Diagnostics: {message}", diag.ToString())
@@ -381,7 +428,11 @@ let solutionFindAndLoadOnDir
 
             return! solutionTryLoadFromProjectFiles lspClient logMessage progressReport projFiles
 
-        | Some solutionPath -> return! solutionTryLoadOnPath lspClient solutionPath
+        | Some solutionPath ->
+            let progressReport (message, percent) =
+                progressReporter.Report(false, message, percent)
+
+            return! solutionTryLoadOnPath lspClient progressReport solutionPath
     }
 
 let solutionLoadSolutionWithPathOrOnDir
@@ -397,7 +448,10 @@ let solutionLoadSolutionWithPathOrOnDir
             | true -> solutionPath
             | false -> Path.Combine(dir, solutionPath)
 
-        return! solutionTryLoadOnPath lspClient rootedSolutionPath
+        let progressReport (message, percent) =
+            progressReporter.Report(false, message, percent)
+
+        return! solutionTryLoadOnPath lspClient progressReport rootedSolutionPath
       }
 
     | None -> async {

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/App/App.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/App/App.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lib\Lib.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/App/Program.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/App/Program.cs
@@ -1,0 +1,9 @@
+namespace App;
+
+public class Program
+{
+    public static string Run(string name)
+    {
+        return Lib.Helper.Describe(name);
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/Lib/Helper.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/Lib/Helper.cs
@@ -1,0 +1,9 @@
+namespace Lib;
+
+public class Helper
+{
+    public static string Describe(string name)
+    {
+        return "helper " + name;
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/Lib/Lib.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/Lib/Lib.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/solutionWithOutOfSlnReference.sln
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithOutOfSlnReference/solutionWithOutOfSlnReference.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "App", "App\App.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/CSharpLanguageServer.Tests/InitializationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InitializationTests.fs
@@ -545,3 +545,82 @@ let testInitializeSucceedsWhenRootPathIsNotAValidUri () =
 
     Assert.That(client.ServerDidRespondTo "initialize", Is.True)
     Assert.That(client.ClientDidSendNotification "initialized", Is.True)
+
+[<Test>]
+let testSolutionLoadReportsPerProjectProgress () =
+    use client = activateFixture "nestedProjects"
+    use scratchDocument = client.Open("App/Tests/Scratch.cs")
+
+    // any position request blocks until the workspace load completes,
+    // so once it answers the full load progress is in the rpc log
+    let hoverParams: HoverParams =
+        { TextDocument = { Uri = scratchDocument.Uri }
+          Position = { Line = 0u; Character = 17u }
+          WorkDoneToken = None }
+
+    let _hover: Hover option = client.Request("textDocument/hover", hoverParams)
+
+    let reports =
+        client.GetRpcLog()
+        |> Seq.filter (fun m ->
+            m.Source = Server
+            && (Some m.Message |> jeStringProp "method") = Some "$/progress")
+        |> Seq.map (fun m -> Some m.Message |> indexJE "params" |> indexJE "value")
+        |> Seq.filter (fun v -> (v |> jeStringProp "kind") = Some "report")
+        |> Seq.map (fun v ->
+            (v |> jeStringProp "message" |> Option.defaultValue ""),
+            (v |> indexJE "percentage" |> Option.map _.GetUInt32()))
+        |> List.ofSeq
+
+    // the fixture solution has two projects, so the load reports two
+    // per-project completions with rising percentages
+    let projectReports = reports |> List.filter (fun (msg, _) -> msg.EndsWith "/2)")
+
+    Assert.That(List.length projectReports, Is.EqualTo(2), sprintf "all report-kind progress seen: %A" reports)
+
+    let percentages = projectReports |> List.choose snd
+
+    Assert.That((percentages = List.sort percentages), Is.True, "percentages should be monotonic")
+    Assert.That(percentages |> List.forall (fun p -> p <= 100u), Is.True)
+    Assert.That(List.last percentages, Is.EqualTo(100u))
+
+[<Test>]
+let testSolutionLoadProgressStaysWithinBoundsWithOutOfSolutionReferences () =
+    // The solution lists one project, but it references another project that
+    // is not a solution member; LoadMetadataForReferencedProjects makes the
+    // workspace load that one too, so more projects load than the solution
+    // file declares. Progress must still stay monotonic and within 100%.
+    use client = activateFixture "solutionWithOutOfSlnReference"
+    use programDocument = client.Open("App/Program.cs")
+
+    let hoverParams: HoverParams =
+        { TextDocument = { Uri = programDocument.Uri }
+          Position = { Line = 4u; Character = 26u }
+          WorkDoneToken = None }
+
+    let _hover: Hover option = client.Request("textDocument/hover", hoverParams)
+
+    let reports =
+        client.GetRpcLog()
+        |> Seq.filter (fun m ->
+            m.Source = Server
+            && (Some m.Message |> jeStringProp "method") = Some "$/progress")
+        |> Seq.map (fun m -> Some m.Message |> indexJE "params" |> indexJE "value")
+        |> Seq.filter (fun v -> (v |> jeStringProp "kind") = Some "report")
+        |> Seq.map (fun v ->
+            (v |> jeStringProp "message" |> Option.defaultValue ""),
+            (v |> indexJE "percentage" |> Option.map _.GetUInt32()))
+        |> List.ofSeq
+
+    let projectReports = reports |> List.filter (fun (msg, _) -> msg.Contains "/")
+
+    Assert.That(List.length projectReports, Is.GreaterThanOrEqualTo(2), sprintf "reports seen: %A" reports)
+
+    let percentages = projectReports |> List.choose snd
+    Assert.That((percentages = List.sort percentages), Is.True, "percentages should be monotonic")
+
+    Assert.That(
+        percentages |> List.forall (fun p -> p <= 100u),
+        Is.True,
+        sprintf "percentages should never exceed 100, got %A" percentages
+    )


### PR DESCRIPTION
Loading a big solution can take many seconds, and today the only
workDoneProgress signals around it are the begin and end events. Requests
issued during the load block for exactly the remaining load time, so a per
project percentage lets a client display progress and estimate how long
until the server answers.

This PR wires the IProgress overload of OpenSolutionAsync into the existing
progress arc: one report per project, counted on its first Resolve
operation (a project goes through its Evaluate/Build/Resolve sequence once
per target framework), forwarded through a mailbox so reports reach the
client in the order they were produced without blocking the loader
callback. LoadMetadataForReferencedProjects can pull in projects that are
not solution members, so the denominator widens as they appear and the
percentage stays monotonic and at most 100. The project-file load path
already reported per project progress; both paths now emit the same
message shape.

Two integration tests pin the behavior over a running server: a two
project solution reports two per project completions with rising
percentages, and a solution referencing a project outside its member list
(new fixture) keeps the percentage monotonic and at most 100. CHANGELOG.md
entry included.
