### PR TITLE
fix: match request uris to workspace folders case-insensitively on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Match request uris to workspace folders case-insensitively on Windows: Windows paths are case-insensitive, and a client may send a differently cased uri (for example a lowercase drive letter) than the announced workspace root, which previously made requests silently miss the workspace and answer null
+  - By @pbednarcik
 * Fix `textDocument/references` with `includeDeclaration` crashing (`-32603 Internal error`) on a symbol from an assembly not referenced by an arbitrary "first" project in the solution; metadata locations are now resolved against the project that owns the requesting document instead
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/416
 

--- a/src/CSharpLanguageServer/Lsp/Workspace.fs
+++ b/src/CSharpLanguageServer/Lsp/Workspace.fs
@@ -148,11 +148,20 @@ let workspaceFoldersReplaced (workspaceFolders: WorkspaceFolder list) (workspace
         Folders = folders
         Phase = LspWorkspacePhase.Configured }
 
+// Windows filesystems are case-insensitive, so two uris differing only in
+// casing name the same file there (a client may e.g. send a lowercase drive
+// letter while the workspace root was announced with an uppercase one); on
+// other platforms casing stays significant.
+let private uriComparison =
+    match Environment.OSVersion.Platform with
+    | PlatformID.Win32NT -> StringComparison.OrdinalIgnoreCase
+    | _ -> StringComparison.Ordinal
+
 let private uriIsWithin (baseUri: string) (uri: string) =
     let baseUri = baseUri.TrimEnd('/')
 
-    uri.Equals(baseUri, StringComparison.Ordinal)
-    || uri.StartsWith(baseUri + "/", StringComparison.Ordinal)
+    uri.Equals(baseUri, uriComparison)
+    || uri.StartsWith(baseUri + "/", uriComparison)
 
 let workspaceFolder (uri: string) (workspace: LspWorkspace) =
     let workspaceFolderMatchesUri wf =

--- a/tests/CSharpLanguageServer.Tests/HoverTests.fs
+++ b/tests/CSharpLanguageServer.Tests/HoverTests.fs
@@ -90,3 +90,40 @@ let testHoverWorksInRazorFile () =
         Assert.That(c.Value.ReplaceLineEndings("\n"), Is.EqualTo("```csharp\nstring? IndexViewModel.Output\n```"))
 
     | _ -> failwith "Some (U3.C1 c) was expected"
+
+[<Test>]
+let testHoverWorksWithLowercasedDriveLetterUri () =
+    use client = activateFixture "genericProject"
+    use classFile = client.Open("Project/Class.cs")
+
+    // A client may send a lowercase drive letter while the workspace root was
+    // announced with an uppercase one; on windows both name the same file.
+    // On non-windows paths (no drive letter) the rewrite is a no-op.
+    let lowercasedUri =
+        System.Text.RegularExpressions.Regex.Replace(
+            classFile.Uri,
+            "^file:///([A-Z]):",
+            fun m -> "file:///" + m.Groups[1].Value.ToLowerInvariant() + ":"
+        )
+
+    // a didOpen with the mismatched casing must reach the document too
+    let didOpenParams: DidOpenTextDocumentParams =
+        { TextDocument =
+            { Uri = lowercasedUri
+              LanguageId = "csharp"
+              Version = 1
+              Text = System.IO.File.ReadAllText(System.Uri(classFile.Uri).LocalPath) } }
+
+    client.Notify("textDocument/didOpen", didOpenParams)
+
+    let hoverParams: HoverParams =
+        { TextDocument = { Uri = lowercasedUri }
+          Position = { Line = 4u; Character = 16u }
+          WorkDoneToken = None }
+
+    let hover: Hover option = client.Request("textDocument/hover", hoverParams)
+
+    match hover with
+    | Some { Contents = U3.C1 c } ->
+        Assert.That(c.Value.ReplaceLineEndings("\n"), Is.EqualTo("```csharp\nvoid Class.MethodA(string arg)\n```"))
+    | _ -> Assert.Fail("hover through a lowercased drive-letter uri should answer contents")

--- a/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
@@ -140,3 +140,29 @@ let ``an additional-document-only path resolves to none`` () =
         Is.True,
         "a path known only as an additional document is not a source document"
     )
+
+[<Test>]
+let ``workspace folder routing matches a differently cased uri on windows`` () =
+    let workspace =
+        { CSharpLanguageServer.Lsp.Workspace.LspWorkspace.Empty with
+            Folders =
+                [ { LspWorkspaceFolder.Empty with
+                      Uri = "file:///C:/Temp/CasingRoot" } ] }
+
+    let resolved =
+        workspace
+        |> CSharpLanguageServer.Lsp.Workspace.workspaceFolder "file:///c:/temp/casingroot/File.cs"
+
+    match Environment.OSVersion.Platform with
+    | PlatformID.Win32NT ->
+        Assert.That(
+            resolved.IsSome,
+            Is.True,
+            "windows filesystems are case-insensitive, so routing should match a differently cased uri"
+        )
+    | _ ->
+        Assert.That(
+            resolved.IsNone,
+            Is.True,
+            "path casing is significant on non-windows filesystems, so routing should not match"
+        )


### PR DESCRIPTION
A request uri resolves to a workspace folder by string-prefix comparison
against the folder root uri, and that comparison used
StringComparison.Ordinal. Windows filesystems are case-insensitive, so a
client that cases a uri differently than the announced workspace root (a
lowercase drive letter, or an all-lowercase path) still names the same
file, but the comparison missed and the request silently fell through:
position requests answered null and didOpen was dropped without effect.
The document lookup below the routing already compares case-insensitively
on every platform, so routing was the only case-sensitive link.

This PR compares with OrdinalIgnoreCase on Windows only; other platforms
keep Ordinal since their filesystems are case-sensitive.

Two tests: a routing unit test with a differently cased uri
(platform-branched: resolves on Windows, stays unmatched elsewhere), and
an integration test proving a didOpen plus hover through a
lowercased-drive uri answers full contents. CHANGELOG.md entry included.
