### PR TITLE
Fix multi-targeted projects answering null to every position-based request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Fix every position-based request answering null on multi-targeted projects: a file of a `<TargetFrameworks>` project has one Roslyn document per target framework, which the document lookup treated as ambiguous and resolved to `None`; the lookup now picks the flavor with the best TFM (same rule as workspace-global TFM selection, mirroring how Visual Studio auto-selects a default project context), leaving genuinely linked files (one path in different project files) ambiguous as before
+  - By @pbednarcik
 * Report per-project progress while loading a solution: `$/progress` reports now carry a message like `Project (34/88)` and a monotonically increasing percentage, so clients can display load progress and estimate readiness
   - By @pbednarcik in https://github.com/razzmatazz/csharp-language-server/pull/417
 * Match request uris to workspace folders case-insensitively on Windows: Windows paths are case-insensitive, and a client may send a differently cased uri (for example a lowercase drive letter) than the announced workspace root, which previously made requests silently miss the workspace and answer null

--- a/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
+++ b/src/CSharpLanguageServer/Lsp/WorkspaceFolder.fs
@@ -409,6 +409,37 @@ let workspaceFolderSymbolsLocations
         return results |> List.rev, aggregatedWfUpdates
     }
 
+/// Pick which target-framework flavor of a multi-targeted project answers for
+/// a document. MSBuildWorkspace names the flavors "Project(net10.0)" style, so
+/// the TFM is recovered from the project name and the same bestTfm rule that
+/// drives workspace-global TFM selection picks the winner -- mirroring how
+/// Visual Studio auto-selects a default project context for a document. When
+/// no name yields a TFM, fall back to a stable name sort so the answer is
+/// deterministic but never None.
+let private selectMultiTfmFlavor (docs: Document list) : Document =
+    let flavorTfm (d: Document) =
+        let name = d.Project.Name
+        let openIdx = name.LastIndexOf '('
+
+        if openIdx >= 0 && name.EndsWith ")" then
+            name.Substring(openIdx + 1, name.Length - openIdx - 2) |> tryNormalizeTfm
+        else
+            None
+
+    let parsedFlavors =
+        docs |> List.choose (fun d -> flavorTfm d |> Option.map (fun tfm -> d, tfm))
+
+    let bestFlavorMaybe =
+        parsedFlavors
+        |> List.map snd
+        |> bestTfm
+        |> Option.bind (fun best -> parsedFlavors |> List.tryFind (fun (_, tfm) -> tfm = best))
+        |> Option.map fst
+
+    match bestFlavorMaybe with
+    | Some doc -> doc
+    | None -> docs |> List.sortBy (fun d -> d.Project.Name) |> List.head
+
 let workspaceFolderDocumentDetails docType (u: string) (wf: LspWorkspaceFolder) =
     match wf.Solution with
     | Uninitialized -> None
@@ -418,16 +449,14 @@ let workspaceFolderDocumentDetails docType (u: string) (wf: LspWorkspaceFolder) 
         // Indexed lookup instead of scanning every document of every project:
         // this runs on every position-based request, so on a large solution
         // the scan (which also allocated a Uri per document for the
-        // comparison) dominates the per-request cost. Multiple ids for one
-        // path (e.g. a multi-targeted or linked file) keep resolving to None,
-        // matching the previous exactly-one-match behavior.
+        // comparison) dominates the per-request cost.
         let matchingUserDocumentMaybe =
             workspaceFolderUriToPath u wf
             |> Option.bind (fun path ->
                 // The ids can include non-source documents (additional /
                 // analyzer-config files, depending on the Roslyn version), so
-                // resolve through GetDocument first and require exactly one
-                // SOURCE document, matching the previous scan over
+                // resolve through GetDocument first and only count SOURCE
+                // documents, matching the previous scan over
                 // project.Documents only.
                 match
                     solution.GetDocumentIdsWithFilePath path
@@ -435,7 +464,26 @@ let workspaceFolderDocumentDetails docType (u: string) (wf: LspWorkspaceFolder) 
                     |> List.ofSeq
                 with
                 | [ doc ] -> Some doc
-                | _ -> None)
+                | [] -> None
+                | (doc :: _) as docs ->
+                    // Several source documents for one path: a multi-targeted
+                    // project loads as one Roslyn project per target framework,
+                    // all sharing the same project FilePath, and every source
+                    // file in it appears once per flavor. Those are the same
+                    // file, so pick a flavor rather than answer None -- None
+                    // here makes every position-based request on the project
+                    // answer null (#75, #198). A path shared by *different*
+                    // project files (a linked file) stays ambiguous, as before.
+                    let projectFilePath = doc.Project.FilePath
+
+                    let allFlavorsOfOneProject =
+                        not (String.IsNullOrEmpty projectFilePath)
+                        && docs |> List.forall (fun d -> d.Project.FilePath = projectFilePath)
+
+                    if allFlavorsOfOneProject then
+                        Some(selectMultiTfmFlavor docs)
+                    else
+                        None)
             |> Option.map (fun d -> d, UserDocument)
 
         let matchingDecompiledDocumentMaybe =

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -174,7 +174,7 @@ let frameworkIsCompatible a b =
 /// Normalise a declared TFM to its canonical short folder name so that equivalent
 /// spellings intersect correctly.  Returns None for values NuGet cannot make sense of
 /// (GetShortFolderName throws on unsupported frameworks).
-let private tryNormalizeTfm (tfm: string) : string option =
+let tryNormalizeTfm (tfm: string) : string option =
     try
         let fx = NuGetFramework.Parse tfm
 

--- a/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Lib/Helper.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Lib/Helper.cs
@@ -1,0 +1,6 @@
+class Helper
+{
+    public void Help()
+    {
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Lib/Lib.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Lib/Lib.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Project/Class.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Project/Class.cs
@@ -1,0 +1,8 @@
+class Class
+{
+#if NET8_0
+    public void Method(string arg)
+    {
+    }
+#endif
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Project/Project.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/Project/Project.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/multiTargetProjectNoCommonTfm.sln
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/multiTargetProjectNoCommonTfm/multiTargetProjectNoCommonTfm.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Project", "Project\Project.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Lib", "Lib\Lib.csproj", "{44444444-4444-4444-4444-444444444444}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44444444-4444-4444-4444-444444444444}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44444444-4444-4444-4444-444444444444}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44444444-4444-4444-4444-444444444444}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44444444-4444-4444-4444-444444444444}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/CSharpLanguageServer.Tests/InitializationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InitializationTests.fs
@@ -201,6 +201,22 @@ let testMultiTargetProjectLoads () =
 
     Assert.That(client.ServerMessageLogContains(fun m -> m.Contains "loading project"), Is.True)
 
+/// Unlike the fixture above, this solution has no TFM common to every project, so the
+/// workspace-global TargetFramework property (issues #75 / #198) does not engage and the
+/// multi-targeted project genuinely loads as one Roslyn project per TFM flavor.  Document
+/// lookup used to read those flavors as ambiguity and answer null to every position-based
+/// request on the project.  The hovered method only exists under NET8_0, so this also
+/// verifies the best-TFM flavor (net8.0, not net6.0) is the one answering.
+[<Test>]
+let testMultiTargetProjectWithNoCommonTfmAnswersFromBestFlavor () =
+    use client = activateFixture "multiTargetProjectNoCommonTfm"
+
+    assertHoverWorks
+        client
+        "Project/Class.cs"
+        { Line = 3u; Character = 16u }
+        "```csharp\nvoid Class.Method(string arg)\n```"
+
 /// Regression test for https://github.com/razzmatazz/csharp-language-server/issues/405:
 /// a solution mixing a plain net10.0 project with a net10.0-windows one used to have the
 /// platform-specific TFM applied as a workspace-global MSBuild property, overriding the

--- a/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
@@ -97,6 +97,77 @@ let ``a path shared by two projects resolves to none`` () =
         "an ambiguous path (linked into two projects) should resolve to None"
     )
 
+/// Build a solution holding one multi-targeted project: one Roslyn project per
+/// flavor name, all sharing the same project FilePath (as MSBuildWorkspace
+/// produces for <TargetFrameworks>), each holding the same source file.
+let private makeMultiTfmSolution (baseName: string) (flavorNames: string list) =
+    let projectFilePath = testFilePath (baseName + ".csproj")
+    let path = testFilePath (baseName + ".cs")
+    let ws = new AdhocWorkspace()
+
+    let addFlavor (solution: Solution) name =
+        let projectInfo =
+            ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                name,
+                baseName,
+                LanguageNames.CSharp,
+                filePath = projectFilePath
+            )
+
+        let solution = solution.AddProject(projectInfo)
+        addSourceDocument solution projectInfo.Id (baseName + ".cs") path
+
+    let solution = flavorNames |> List.fold addFlavor ws.CurrentSolution
+    makeWorkspaceFolder solution, path
+
+// A multi-targeted project loads as one Roslyn project per target framework,
+// all sharing the same project FilePath, so every source file in it has
+// several DocumentIds. That must not read as ambiguity: the flavors hold the
+// same file, and answering None would turn every position-based request on
+// the project into a null answer.
+
+[<Test>]
+let ``a multi targeted project resolves to its best tfm flavor`` () =
+    let wf, path =
+        makeMultiTfmSolution
+            "MultiTfm"
+            [ "MultiTfm(net472)"
+              "MultiTfm(netstandard2.0)"
+              "MultiTfm(net8.0)"
+              "MultiTfm(net10.0)" ]
+
+    match workspaceFolderDocument AnyDocument (fileUri path) wf with
+    | Some doc -> Assert.That(doc.Project.Name, Is.EqualTo("MultiTfm(net10.0)"))
+    | None -> Assert.Fail("a file of a multi-targeted project should resolve to one of its flavors")
+
+[<Test>]
+let ``the chosen flavor does not depend on project insertion order`` () =
+    let wf, path =
+        makeMultiTfmSolution
+            "MultiTfmReversed"
+            [ "MultiTfmReversed(net10.0)"
+              "MultiTfmReversed(net8.0)"
+              "MultiTfmReversed(netstandard2.0)"
+              "MultiTfmReversed(net472)" ]
+
+    match workspaceFolderDocument AnyDocument (fileUri path) wf with
+    | Some doc -> Assert.That(doc.Project.Name, Is.EqualTo("MultiTfmReversed(net10.0)"))
+    | None -> Assert.Fail("a file of a multi-targeted project should resolve to one of its flavors")
+
+[<Test>]
+let ``flavors without a parseable tfm still resolve deterministically`` () =
+    // Flavor names are produced by MSBuildWorkspace, but nothing guarantees
+    // the "(tfm)" suffix; when no name yields a TFM the lookup must still
+    // answer (stable name-sorted first), never None.
+    let wf, path =
+        makeMultiTfmSolution "MultiTfmOdd" [ "MultiTfmOdd beta"; "MultiTfmOdd alpha"; "MultiTfmOdd gamma" ]
+
+    match workspaceFolderDocument AnyDocument (fileUri path) wf with
+    | Some doc -> Assert.That(doc.Project.Name, Is.EqualTo("MultiTfmOdd alpha"))
+    | None -> Assert.Fail("unparseable flavor names should fall back to a deterministic pick, not None")
+
 [<Test>]
 let ``a path that is also an additional document still resolves to the source document`` () =
     // GetDocumentIdsWithFilePath returns ids for ALL document kinds, so the

--- a/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
+++ b/tests/CSharpLanguageServer.Tests/WorkspaceFolderTests.fs
@@ -122,39 +122,11 @@ let private makeMultiTfmSolution (baseName: string) (flavorNames: string list) =
     let solution = flavorNames |> List.fold addFlavor ws.CurrentSolution
     makeWorkspaceFolder solution, path
 
-// A multi-targeted project loads as one Roslyn project per target framework,
-// all sharing the same project FilePath, so every source file in it has
-// several DocumentIds. That must not read as ambiguity: the flavors hold the
-// same file, and answering None would turn every position-based request on
-// the project into a null answer.
-
-[<Test>]
-let ``a multi targeted project resolves to its best tfm flavor`` () =
-    let wf, path =
-        makeMultiTfmSolution
-            "MultiTfm"
-            [ "MultiTfm(net472)"
-              "MultiTfm(netstandard2.0)"
-              "MultiTfm(net8.0)"
-              "MultiTfm(net10.0)" ]
-
-    match workspaceFolderDocument AnyDocument (fileUri path) wf with
-    | Some doc -> Assert.That(doc.Project.Name, Is.EqualTo("MultiTfm(net10.0)"))
-    | None -> Assert.Fail("a file of a multi-targeted project should resolve to one of its flavors")
-
-[<Test>]
-let ``the chosen flavor does not depend on project insertion order`` () =
-    let wf, path =
-        makeMultiTfmSolution
-            "MultiTfmReversed"
-            [ "MultiTfmReversed(net10.0)"
-              "MultiTfmReversed(net8.0)"
-              "MultiTfmReversed(netstandard2.0)"
-              "MultiTfmReversed(net472)" ]
-
-    match workspaceFolderDocument AnyDocument (fileUri path) wf with
-    | Some doc -> Assert.That(doc.Project.Name, Is.EqualTo("MultiTfmReversed(net10.0)"))
-    | None -> Assert.Fail("a file of a multi-targeted project should resolve to one of its flavors")
+// The happy path of multi-TFM flavor selection is covered by an integration test
+// (InitializationTests.testMultiTargetProjectWithNoCommonTfmAnswersFromBestFlavor,
+// on the multiTargetProjectNoCommonTfm fixture). The fallback below stays a unit
+// test: a real MSBuildWorkspace load always names flavors with the "(tfm)" suffix,
+// so a flavor name without one cannot be produced through a fixture.
 
 [<Test>]
 let ``flavors without a parseable tfm still resolve deterministically`` () =


### PR DESCRIPTION
Fixes the document lookup answering `None` for every file of a multi-targeted project, which makes all position-based requests (hover, documentSymbol, definition, references, ...) answer null while the solution load reports success. Follow-up to the experimental multi-TFM support from #205 (issues #75 / #198): that support picks one workspace-global `TargetFramework`, but only when every project declares a common TFM. On solutions where no common TFM exists the global property cannot engage, each project loads with all of its flavors, every file gets one Roslyn document per flavor, and the exactly-one-match document lookup then resolves each of them to `None`.

I hit this driving csharp-ls against dotnet/roslyn itself (heterogeneous TFM sets across ~120 projects of Compilers.slnf): the solution loads fine, then every request answers null.

What this PR does:

* When all source documents for a request path belong to one project file (the multi-target shape), the lookup now answers with the flavor whose TFM wins the existing `bestTfm` rule (the same rule the workspace-global TFM selection uses). This mirrors how Visual Studio auto-selects a default project context for a document in a multi-targeted project.
* Flavor names without a parseable `"(tfm)"` suffix fall back to a stable name sort, so the answer stays deterministic and never regresses to `None`.
* A path shared by *different* project files (a genuinely linked file) stays ambiguous and keeps answering `None`, exactly as before.
* `tryNormalizeTfm` is made non-private so the lookup can reuse it; no behavior change.

Tests: four new cases in `WorkspaceFolderTests` (best-TFM winner across four flavors, insertion-order independence, unparseable-name fallback, and the existing linked-file ambiguity case unchanged). Full suite green on Windows (316/316).

One more thought, not part of this PR: VS answers the "which flavor" question by letting the client pick, via its project context extension (`textDocument/_vs_getProjectContexts` plus an optional `_vs_projectContext` on the text document identifier). Since the lookup now sees the full flavor list before choosing, wiring that in later should be straightforward, with this PR's rule staying as the default when the client sends no context. I'm considering doing that as a follow-up.
