### PR TITLE
Honor .slnf solution filters when reading the solution's project set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Fix `.slnf` solution filters being ignored when the declared project set is read from the solution: the set was read from the filter's parent solution, so on a filtered solution the load progress reported counts like `(74/358)` with the percentage stuck at 20, and the workspace-global `TargetFramework` intersection wrongly included projects the filter excludes
+  - By @pbednarcik
 * Fix `textDocument/completion` (and other interactive requests) stalling when analyzers are enabled on a multi-project solution: `workspace/diagnostic` now analyzes one project at a time instead of fanning out across every project concurrently
   - By @razzmatazz in https://github.com/razzmatazz/csharp-language-server/pull/421
 * Fix every position-based request answering null on multi-targeted projects: a file of a `<TargetFrameworks>` project has one Roslyn document per target framework, which the document lookup treated as ambiguous and resolved to `None`; the lookup now picks the flavor with the best TFM (same rule as workspace-global TFM selection, mirroring how Visual Studio auto-selects a default project context), leaving genuinely linked files (one path in different project files) ambiguous as before

--- a/src/CSharpLanguageServer/Roslyn/Solution.fs
+++ b/src/CSharpLanguageServer/Roslyn/Solution.fs
@@ -2,6 +2,7 @@ module CSharpLanguageServer.Roslyn.Solution
 
 open System
 open System.IO
+open System.Reflection
 open System.Threading
 open System.Collections.Generic
 open System.Xml.Linq
@@ -67,14 +68,52 @@ let initializeMSBuild () : unit =
 
     MSBuildLocator.RegisterInstance(vsInstance)
 
+/// Tells whether a project of this solution survives its `.slnf` filter, answering
+/// true for every project when the solution is not a filter.
+///
+/// MSBuild applies the filter internally but exposes no public way to query it, so
+/// this reaches its own `ProjectShouldBuild` rather than reimplementing the match:
+/// that normalizes path separators and compares case-sensitively on Linux only, and
+/// a hand-written comparison is what would make us disagree with the build about
+/// which projects a filter selects.
+///
+/// Unlike the Roslyn internals reflected elsewhere in this server, Microsoft.Build
+/// is whichever assembly MSBuildLocator found in the installed SDK, so a member that
+/// stops existing must not fail the whole solution load: it degrades to loading
+/// every project the solution declares.
+let private projectShouldBuildPredicate (solutionFile: SolutionFile) : string -> bool =
+    match typeof<SolutionFile>.GetMethod("ProjectShouldBuild", BindingFlags.Instance ||| BindingFlags.NonPublic) with
+    | null ->
+        logger.LogWarning(
+            "MSBuild SolutionFile has no ProjectShouldBuild method; .slnf solution filters will be ignored"
+        )
+
+        fun _ -> true
+
+    | projectShouldBuild ->
+        fun relativePath ->
+            projectShouldBuild.Invoke(solutionFile, [| relativePath |])
+            |> nonNull "SolutionFile.ProjectShouldBuild()"
+            |> unbox<bool>
+
 let solutionLoadProjectFilenames (solutionPath: string) =
     assert Path.IsPathRooted solutionPath
     let projectFilenames = new List<string>()
 
     let solutionFile = SolutionFile.Parse solutionPath
 
+    // For a .slnf, ProjectsInOrder lists every project of the PARENT solution, not
+    // just the filtered set. Without applying the filter a filtered solution
+    // over-counts the load-progress denominator (reports like "(74/358)" stuck at
+    // 20% on dotnet/roslyn's Compilers.slnf) and widens the workspace-global TFM
+    // intersection to projects the filter excludes.
+    let projectShouldBuild = projectShouldBuildPredicate solutionFile
+
     for project in solutionFile.ProjectsInOrder do
-        if project.ProjectType = SolutionProjectType.KnownToBeMSBuildFormat then
+        if
+            project.ProjectType = SolutionProjectType.KnownToBeMSBuildFormat
+            && projectShouldBuild project.RelativePath
+        then
             projectFilenames.Add project.AbsolutePath
 
     projectFilenames |> Set.ofSeq

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/Full.sln
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/Full.sln
@@ -1,0 +1,33 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectA", "ProjectA\ProjectA.csproj", "{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectB", "ProjectB\ProjectB.csproj", "{B2B2B2B2-B2B2-B2B2-B2B2-B2B2B2B2B2B2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectC", "ProjectC\ProjectC.csproj", "{C3C3C3C3-C3C3-C3C3-C3C3-C3C3C3C3C3C3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2B2B2B2-B2B2-B2B2-B2B2-B2B2B2B2B2B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2B2B2B2-B2B2-B2B2-B2B2-B2B2B2B2B2B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2B2B2B2-B2B2-B2B2-B2B2-B2B2B2B2B2B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2B2B2B2-B2B2-B2B2-B2B2-B2B2B2B2B2B2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3C3C3C3-C3C3-C3C3-C3C3-C3C3C3C3C3C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3C3C3C3-C3C3-C3C3-C3C3-C3C3C3C3C3C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3C3C3C3-C3C3-C3C3-C3C3-C3C3C3C3C3C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3C3C3C3-C3C3-C3C3-C3C3-C3C3C3C3C3C3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/Partial.slnf
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/Partial.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "Full.sln",
+    "projects": [
+      "ProjectA\\ProjectA.csproj",
+      "ProjectC\\ProjectC.csproj"
+    ]
+  }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectA/Class.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectA/Class.cs
@@ -1,0 +1,6 @@
+class ClassA
+{
+    public void MethodA(string arg)
+    {
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectA/ProjectA.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectA/ProjectA.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectB/Class.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectB/Class.cs
@@ -1,0 +1,6 @@
+class ClassB
+{
+    public void MethodB(string arg)
+    {
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectB/ProjectB.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectB/ProjectB.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectC/Class.cs
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectC/Class.cs
@@ -1,0 +1,6 @@
+class ClassC
+{
+    public void MethodC(string arg)
+    {
+    }
+}

--- a/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectC/ProjectC.csproj
+++ b/tests/CSharpLanguageServer.Tests/Fixtures/solutionWithFilter/ProjectC/ProjectC.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+    </PropertyGroup>
+</Project>

--- a/tests/CSharpLanguageServer.Tests/InitializationTests.fs
+++ b/tests/CSharpLanguageServer.Tests/InitializationTests.fs
@@ -562,6 +562,19 @@ let testInitializeSucceedsWhenRootPathIsNotAValidUri () =
     Assert.That(client.ServerDidRespondTo "initialize", Is.True)
     Assert.That(client.ClientDidSendNotification "initialized", Is.True)
 
+/// Every report-kind `$/progress` value the server sent so far, as (message, percentage).
+let loadProgressReports (client: LspTestClient) =
+    client.GetRpcLog()
+    |> Seq.filter (fun m ->
+        m.Source = Server
+        && (Some m.Message |> jeStringProp "method") = Some "$/progress")
+    |> Seq.map (fun m -> Some m.Message |> indexJE "params" |> indexJE "value")
+    |> Seq.filter (fun v -> (v |> jeStringProp "kind") = Some "report")
+    |> Seq.map (fun v ->
+        (v |> jeStringProp "message" |> Option.defaultValue ""),
+        (v |> indexJE "percentage" |> Option.map _.GetUInt32()))
+    |> List.ofSeq
+
 [<Test>]
 let testSolutionLoadReportsPerProjectProgress () =
     use client = activateFixture "nestedProjects"
@@ -576,17 +589,7 @@ let testSolutionLoadReportsPerProjectProgress () =
 
     let _hover: Hover option = client.Request("textDocument/hover", hoverParams)
 
-    let reports =
-        client.GetRpcLog()
-        |> Seq.filter (fun m ->
-            m.Source = Server
-            && (Some m.Message |> jeStringProp "method") = Some "$/progress")
-        |> Seq.map (fun m -> Some m.Message |> indexJE "params" |> indexJE "value")
-        |> Seq.filter (fun v -> (v |> jeStringProp "kind") = Some "report")
-        |> Seq.map (fun v ->
-            (v |> jeStringProp "message" |> Option.defaultValue ""),
-            (v |> indexJE "percentage" |> Option.map _.GetUInt32()))
-        |> List.ofSeq
+    let reports = loadProgressReports client
 
     // the fixture solution has two projects, so the load reports two
     // per-project completions with rising percentages
@@ -599,6 +602,44 @@ let testSolutionLoadReportsPerProjectProgress () =
     Assert.That((percentages = List.sort percentages), Is.True, "percentages should be monotonic")
     Assert.That(percentages |> List.forall (fun p -> p <= 100u), Is.True)
     Assert.That(List.last percentages, Is.EqualTo(100u))
+
+/// A .slnf solution filter selects a subset of its parent solution.  The declared
+/// project set used to be read from the parent, so on a filtered solution the load
+/// progress counted every project of the parent (reports like "(74/358)" whose
+/// percentage never reached 100) and the workspace-global TFM intersection ran over
+/// the excluded projects too.
+[<Test>]
+let testSolutionLoadProgressCountsOnlySolutionFilterProjects () =
+    let profile =
+        { defaultClientProfile with
+            ServerConfig =
+                { defaultClientProfile.ServerConfig with
+                    solutionPathOverride = Some "Partial.slnf" } }
+
+    use client = activateFixtureExt "solutionWithFilter" profile emptyFixturePatch id
+    use classDocument = client.Open("ProjectA/Class.cs")
+
+    let hoverParams: HoverParams =
+        { TextDocument = { Uri = classDocument.Uri }
+          Position = { Line = 2u; Character = 16u }
+          WorkDoneToken = None }
+
+    let _hover: Hover option = client.Request("textDocument/hover", hoverParams)
+
+    let reports = loadProgressReports client
+
+    // Full.sln declares three projects; Partial.slnf keeps two of them
+    let projectReports = reports |> List.filter (fun (msg, _) -> msg.EndsWith "/2)")
+
+    Assert.That(List.length projectReports, Is.EqualTo(2), sprintf "all report-kind progress seen: %A" reports)
+
+    Assert.That(
+        reports |> List.exists (fun (msg, _) -> msg.EndsWith "/3)"),
+        Is.False,
+        "the filter's parent solution must not set the progress denominator"
+    )
+
+    Assert.That(List.last (projectReports |> List.choose snd), Is.EqualTo(100u))
 
 [<Test>]
 let testSolutionLoadProgressStaysWithinBoundsWithOutOfSolutionReferences () =
@@ -616,17 +657,7 @@ let testSolutionLoadProgressStaysWithinBoundsWithOutOfSolutionReferences () =
 
     let _hover: Hover option = client.Request("textDocument/hover", hoverParams)
 
-    let reports =
-        client.GetRpcLog()
-        |> Seq.filter (fun m ->
-            m.Source = Server
-            && (Some m.Message |> jeStringProp "method") = Some "$/progress")
-        |> Seq.map (fun m -> Some m.Message |> indexJE "params" |> indexJE "value")
-        |> Seq.filter (fun v -> (v |> jeStringProp "kind") = Some "report")
-        |> Seq.map (fun v ->
-            (v |> jeStringProp "message" |> Option.defaultValue ""),
-            (v |> indexJE "percentage" |> Option.map _.GetUInt32()))
-        |> List.ofSeq
+    let reports = loadProgressReports client
 
     let projectReports = reports |> List.filter (fun (msg, _) -> msg.Contains "/")
 

--- a/tests/CSharpLanguageServer.Tests/Tooling.fs
+++ b/tests/CSharpLanguageServer.Tests/Tooling.fs
@@ -559,6 +559,7 @@ let prepareTempTestDirFrom (sourceTestDir: DirectoryInfo) : string =
         || file.Extension = ".csproj"
         || file.Extension = ".sln"
         || file.Extension = ".slnx"
+        || file.Extension = ".slnf"
         || file.Extension = ".cshtml"
         || file.Extension = ".txt"
 


### PR DESCRIPTION
`solutionLoadProjectFilenames` reads `ProjectsInOrder` from `SolutionFile.Parse`, and for a `.slnf` that lists every project of the parent solution, not the filtered set. MSBuild applies the filter internally when building, but the project set we derive from it is wrong, with two visible effects on a filtered solution:

- the load progress denominator counts the whole parent solution. On dotnet/roslyn's `Compilers.slnf` the reports read `(74/358)` and the percentage stopped at 20 (this is the counter from #417, so the bug is mine to fix)
- the workspace-global `TargetFramework` intersection runs over projects the filter excludes, which can disengage the multi-TFM support for no reason

`SolutionFile.ProjectShouldBuild` answers exactly this question but it is internal, so it is resolved by reflection, the way this server already reaches Roslyn internals. It answers true for every project when the solution carries no filter, so it needs no `.slnf` check of its own. `Microsoft.Build` comes from the SDK that MSBuildLocator picked rather than from a pinned package reference, so a member that stops existing logs a warning and degrades to loading every declared project instead of failing the solution load.

Test: a new `solutionWithFilter` fixture (three-project `Full.sln`, `Partial.slnf` keeping two of them) loaded through `solutionPathOverride`. Before the fix the progress reports read `ProjectA (1/3)`, `ProjectC (2/3)` and stopped at 66; with the fix they read `(1/2)`, `(2/2)` and reach 100. The test harness did not copy `.slnf` files into the temp fixture dir, so that is added to the copy filter, and the progress-report collection shared by the load-progress tests moved into a small helper.
